### PR TITLE
Provide endpoint for announcing a dataset update

### DIFF
--- a/datalad_registry/models.py
+++ b/datalad_registry/models.py
@@ -51,6 +51,7 @@ class URL(db.Model):
     url = db.Column(db.Text, primary_key=True)
     dsid = db.Column(db.Text, nullable=False)
     info_ts = db.Column(db.Integer)
+    update_announced = db.Column(db.Integer)
     head = db.Column(db.Text)
     head_describe = db.Column(db.Text)
     branches = db.Column(db.Text)

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -94,11 +94,15 @@ def collect_git_info(urls=None):
                 # Work on a few at a time, letting remaining be
                 # handled by next task.
                 #
-                # TODO: Think about better ways to handle this.
+                # TODO: Think about better ways to handle this (here
+                # and for the update_announced query below).
                 for r in ses.query(URL).filter_by(info_ts=None).limit(3)]
-        # TODO: Look at info_ts timestamp (and other criteria,
-        # including announced update) and refresh previous
+        # TODO: Look at info_ts timestamp and refresh previous
         # information.
+        if not urls:
+            urls = [r.url
+                    for r in ses.query(URL).filter_by(update_announced=1)
+                    .limit(3)]
     if not urls:
         lgr.debug("Did not find URLs that needed information collected")
         return
@@ -118,5 +122,6 @@ def collect_git_info(urls=None):
 
         info = _extract_git_info(str(ds_path))
         info["info_ts"] = time.time()
+        info["update_announced"] = 0
         db.session.query(URL).filter_by(url=url).update(info)
     db.session.commit()

--- a/datalad_registry/tests/test_dataset_urls.py
+++ b/datalad_registry/tests/test_dataset_urls.py
@@ -46,6 +46,13 @@ def test_url_bad_url_get(client, dsid, bad_url):
     assert response.status_code == 400
 
 
+def test_url_unnkown_url_announce(client, dsid):
+    url = "doesnt.matter"
+    url_encoded = url_encode(url)
+    response = client.patch(f"/v1/datasets/{dsid}/urls/{url_encoded}")
+    assert response.status_code == 404
+
+
 def test_register_url(client, dsid, tmp_path):
     dset = tmp_path / "ds"
     dset.mkdir()

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -229,3 +229,13 @@ paths:
                 }
         "400":
           $ref: "#/components/responses/invalid-encoded-url"
+    patch:
+      summary: Announce that dataset at URL has been updated
+      operationId: dataset_urls.url.patch
+      responses:
+        "202":
+          description: Announcement received
+        "400":
+          $ref: "#/components/responses/invalid-encoded-url"
+        "404":
+          description: Unknown URL


### PR DESCRIPTION
This gives `datalad publish/push` a way to announce an update to the
registry.  The underlying task is still very basic in terms of how it
decides to collect information on the URLs and what information it
collects.

---

An example of wiring this up to `datalad push` is at <https://github.com/datalad/datalad/compare/master...kyleam:registry>.