### PR TITLE
views: Extend URL endpoint with some collected information

### DIFF
--- a/datalad_registry/dataset_urls.py
+++ b/datalad_registry/dataset_urls.py
@@ -103,6 +103,7 @@ def url(ds_id, url_encoded):
     if request.method == "GET":
         lgr.info("Checking status of registering %s as URL of %s",
                  url, ds_id)
+        resp = {"ds_id": ds_id, "url": url}
         if row_known is None:
             status = "unknown"
             max_status, = db.session.query(
@@ -112,9 +113,13 @@ def url(ds_id, url_encoded):
                 status = Token.describe_status(max_status)
         else:
             status = "known"
+            resp["info"] = {
+                col: getattr(row_known, col, None)
+                for col in ["annex_uuid", "head", "head_describe"]}
 
         lgr.debug("Status for %s: %s", url, status)
-        return jsonify(ds_id=ds_id, url=url, status=status)
+        resp["status"] = status
+        return jsonify(resp)
     elif request.method == "PATCH":
         if row_known is None:
             return jsonify(message="Invalid encoded URL"), 404

--- a/datalad_registry/dataset_urls.py
+++ b/datalad_registry/dataset_urls.py
@@ -60,7 +60,7 @@ def urls(ds_id):
         lgr.info("Reporting which URLs are registered for %s", ds_id)
         urls = [r.url
                 for r in db.session.query(URL).filter_by(ds_id=ds_id)]
-        return {"ds_id": ds_id, "urls": urls}
+        return jsonify(ds_id=ds_id, urls=urls)
     elif request.method == "POST":
         data = request.json or {}
         try:

--- a/datalad_registry/datasets.py
+++ b/datalad_registry/datasets.py
@@ -4,6 +4,7 @@
 import logging
 
 from flask import Blueprint
+from flask import jsonify
 from flask import request
 from flask import url_for
 
@@ -28,6 +29,6 @@ def datasets():
         # caller doesn't need to construct URL?
         pg_n = url_for(".datasets", page=r.next_num) if r.has_next else None
         pg_p = url_for(".datasets", page=r.prev_num) if r.has_prev else None
-        return {"next": pg_n,
-                "previous": pg_p,
-                "ds_ids": [i.ds_id for i in r.items]}
+        return jsonify({"next": pg_n,
+                        "previous": pg_p,
+                        "ds_ids": [i.ds_id for i in r.items]})

--- a/datalad_registry/tests/test_tasks.py
+++ b/datalad_registry/tests/test_tasks.py
@@ -151,5 +151,11 @@ def test_collect_dataset_info_announced_update(app_instance, tmp_path):
         app_instance.client.patch(f"/v1/datasets/{ds.id}/urls/{url_encoded}")
         tasks.collect_dataset_info()
         res = ses.query(URL).filter_by(url=url).one()
-        assert res.head == repo.get_hexsha()
+        head = repo.get_hexsha()
+        assert res.head == head
         assert res.head_describe == "v2"
+
+        info = app_instance.client.get(
+            f"/v1/datasets/{ds.id}/urls/{url_encoded}").get_json()["info"]
+        assert info["head"] == head
+        assert info["head_describe"] == "v2"

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -221,11 +221,19 @@ paths:
                       - known
                       - URL pending verification
                       - verification failed
+                  info:
+                    description: subset of collected information
+                    type: object
               example:
                 {
                   "ds_id": "6eeadb86-84be-11e6-b24c-002590f97d84",
                   "url": "https://datasets.datalad.org/labs/haxby/raiders/.git",
-                  "status": "known"
+                  "status": "known",
+                  "info": {
+                    "annex_uuid": "524f92ba-0490-462a-9c7a-f8e4d928484a",
+                    "head": "8dcb5e00a00e18e83056c5fe1978afe90d3e9f8f",
+                    "head_describe": "v1"
+                  },
                 }
         "400":
           $ref: "#/components/responses/invalid-encoded-url"


### PR DESCRIPTION
Extend the response for `GET /v1/datasets/{ds_id}/urls/{url_encoded}` with "info" field that includes some of the collected information.

Partially addresses gh-9.
