### PR TITLE
tasks: Switch to DataLad for collecting information

### DIFF
--- a/datalad_registry/tests/test_tasks.py
+++ b/datalad_registry/tests/test_tasks.py
@@ -41,6 +41,7 @@ def test_prune_old_tokens_explcit_cutoff(app_instance, ds_id):
         assert [r.token for r in ses.query(Token)] == ["c", "d"]
 
 
+@pytest.mark.slow
 def test_collect_dataset_info_empty(app_instance):
     with app_instance.app.app_context():
         tasks.collect_dataset_info()
@@ -84,7 +85,7 @@ def test_collect_dataset_info(app_instance, tmp_path):
         assert res.head_describe == "v2"
         assert res.annex_uuid == repo.uuid
         branches = set(ln.split()[1] for ln in res.branches.splitlines())
-        assert branches == set(repo.get_branches())
+        assert branches == set(repo.get_branches()) | {"HEAD"}
         tags = set(ln.split()[1] for ln in res.tags.splitlines())
         assert tags == set(repo.get_tags(output="name"))
 
@@ -120,7 +121,7 @@ def test_collect_dataset_info_just_init(app_instance, tmp_path):
         assert res.head_describe is None
         assert res.annex_uuid == repo.uuid
         branches = set(ln.split()[1] for ln in res.branches.splitlines())
-        assert branches == set(repo.get_branches())
+        assert branches == set(repo.get_branches()) | {"HEAD"}
         assert not res.tags.strip()
 
 

--- a/datalad_registry/tests/utils.py
+++ b/datalad_registry/tests/utils.py
@@ -16,6 +16,20 @@ def make_ds_id():
 
 
 def init_repo_with_token(path, token_response):
+    """Initialize empty repo with a challenge reference.
+
+    This creates a minimal repository suitable for tests that don't
+    need a proper dataset.
+
+    Parameters
+    ----------
+    path : str
+        Initialize repository at this location.
+    token_response : dict
+        A response from the token endpoint.  The value of its "ref"
+        key is used as the challenge reference.
+    """
+    # Note: DataLad is intentionally avoided here.
     sp.run(["git", "init"], cwd=path)
     sp.run(["git", "commit", "--allow-empty", "-mc0"], cwd=path)
     sp.run(["git", "update-ref", token_response["ref"], "HEAD"], cwd=path)


### PR DESCRIPTION
collect_dataset_info() clones the URL with `git clone --mirror ...`.
That's convenient and easy but won't work once we start collecting
more information via DataLad.

Do a fairly minimal switch to using DataLad and a non-bare repo.  If
later desired/needed, some of the call_git() sites can be switched
over to GitRepo methods.

As indicated by the tests, the only change in collected information is
the inclusion of the remote HEAD symref in the list of branches.
That's not a useful addition, but it's also probably not worth
worrying about or filtering out at this point.