### PR TITLE
tasks: Collect number of annex keys at source repository

### DIFF
--- a/datalad_registry/dataset_urls.py
+++ b/datalad_registry/dataset_urls.py
@@ -115,7 +115,8 @@ def url(ds_id, url_encoded):
             status = "known"
             resp["info"] = {
                 col: getattr(row_known, col, None)
-                for col in ["annex_uuid", "head", "head_describe"]}
+                for col in ["annex_uuid", "annex_key_count",
+                            "head", "head_describe"]}
 
         lgr.debug("Status for %s: %s", url, status)
         resp["status"] = status

--- a/datalad_registry/models.py
+++ b/datalad_registry/models.py
@@ -51,6 +51,7 @@ class URL(db.Model):
     url = db.Column(db.Text, primary_key=True)
     ds_id = db.Column(db.Text, nullable=False)
     annex_uuid = db.Column(db.Text)
+    annex_key_count = db.Column(db.Integer)
     info_ts = db.Column(db.Integer)
     update_announced = db.Column(db.Integer)
     head = db.Column(db.Text)

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -84,9 +84,22 @@ def _extract_git_info(repo):
 
 
 def _extract_annex_info(repo):
-    return _extract_info_call_git(
-        repo,
-        {"annex_uuid": ["config", "remote.origin.annex-uuid"]})
+    from datalad.support.exceptions import CommandError
+
+    info = {}
+    try:
+        records = list(repo.call_annex_records(["info"], "origin"))
+    except CommandError as exc:
+        lgr.warning("Running `annex info` in %s had non-zero exit code:\n%s",
+                    repo, exc)
+    except AttributeError:
+        lgr.debug("Skipping annex info collection for non-annex repo: %s",
+                  repo)
+    else:
+        assert len(records) == 1, "bug: unexpected `annex info` output"
+        res = records[0]
+        info["annex_uuid"] = res["uuid"]
+    return info
 
 
 @celery.task

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -99,6 +99,7 @@ def _extract_annex_info(repo):
         assert len(records) == 1, "bug: unexpected `annex info` output"
         res = records[0]
         info["annex_uuid"] = res["uuid"]
+        info["annex_key_count"] = int(res["remote annex keys"])
     return info
 
 

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -54,7 +54,7 @@ def prune_old_tokens(cutoff=None):
     db.session.commit()
 
 
-def _extract_info(repo, commands):
+def _extract_info_call_git(repo, commands):
     from datalad.support.exceptions import CommandError
 
     info = {}
@@ -71,7 +71,7 @@ def _extract_info(repo, commands):
 
 
 def _extract_git_info(repo):
-    return _extract_info(
+    return _extract_info_call_git(
         repo,
         {"head": ["rev-parse", "--verify", "HEAD"],
          "head_describe": ["describe", "--tags"],
@@ -84,7 +84,7 @@ def _extract_git_info(repo):
 
 
 def _extract_annex_info(repo):
-    return _extract_info(
+    return _extract_info_call_git(
         repo,
         {"annex_uuid": ["config", "remote.origin.annex-uuid"]})
 

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -231,6 +231,7 @@ paths:
                   "status": "known",
                   "info": {
                     "annex_uuid": "524f92ba-0490-462a-9c7a-f8e4d928484a",
+                    "annex_key_count": 3,
                     "head": "8dcb5e00a00e18e83056c5fe1978afe90d3e9f8f",
                     "head_describe": "v1"
                   },

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ python_requires = >= 3.7
 install_requires =
     celery >= 5.0
     click
-    datalad >= 0.13
+    datalad >= 0.14
     Flask
     Flask-SQLAlchemy
     SQLAlchemy


### PR DESCRIPTION
Add "annex_key_count" to the info reported by `GET /datasets/{ds_id}/urls/{url_encoded}`.

Closes #10.