### PR TITLE
Add client as DataLad extension

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,4 @@
 [run]
-source = datalad_registry
+source =
+    datalad_registry
+    datalad_registry_client

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,9 @@ jobs:
         pip install codecov
         pip install .
         pip install .[tests]
+    - name: Set up dev server
+      run: ./up-tests
     - name: Run tests
-      run: coverage run -m pytest datalad_registry && coverage xml
+      run: coverage run -m pytest --devserver && coverage xml
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v1

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--devserver", action="store_true", default=False,
+        help="Run tests that depend on Flask development server")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--devserver"):
+        return
+
+    skip_devserver = pytest.mark.skip(
+        reason="--devserver option not specified")
+    for item in items:
+        if "devserver" in item.keywords:
+            item.add_marker(skip_devserver)

--- a/datalad_registry/dataset_urls.py
+++ b/datalad_registry/dataset_urls.py
@@ -123,7 +123,7 @@ def url(ds_id, url_encoded):
         return jsonify(resp)
     elif request.method == "PATCH":
         if row_known is None:
-            return jsonify(message="Invalid encoded URL"), 404
+            return jsonify(message="Unknown URL"), 404
         result.update({"update_announced": 1})
         db.session.commit()
         return "", 202

--- a/datalad_registry/factory.py
+++ b/datalad_registry/factory.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 
 from celery.schedules import crontab
@@ -48,8 +49,10 @@ def setup_celery(app, celery):
     return celery
 
 
-def create_app(test_config=None):
-    app = Flask(__name__)
+def create_app(test_config=None, instance_path=None):
+    app = Flask(
+        __name__,
+        instance_path=os.environ.get("DATALAD_REGISTRY_INSTANCE_PATH"))
     instance_path = Path(app.instance_path)
     db_uri = "sqlite:///" + str(instance_path / "registry.sqlite")
     app.config.from_mapping(

--- a/datalad_registry_client/__init__.py
+++ b/datalad_registry_client/__init__.py
@@ -1,0 +1,3 @@
+
+command_suite = ("Interact with DataLad registry",
+                 [])

--- a/datalad_registry_client/__init__.py
+++ b/datalad_registry_client/__init__.py
@@ -3,4 +3,8 @@ command_suite = ("Interact with DataLad registry",
                  [("datalad_registry_client.submit",
                    "RegistrySubmit",
                    "registry-submit",
-                   "registry_submit")])
+                   "registry_submit"),
+                  ("datalad_registry_client.announce_update",
+                   "RegistryAnnounceUpdate",
+                   "registry-announce-update",
+                   "registry_announce_update")])

--- a/datalad_registry_client/__init__.py
+++ b/datalad_registry_client/__init__.py
@@ -1,3 +1,6 @@
 
 command_suite = ("Interact with DataLad registry",
-                 [])
+                 [("datalad_registry_client.submit",
+                   "RegistrySubmit",
+                   "registry-submit",
+                   "registry_submit")])

--- a/datalad_registry_client/announce_update.py
+++ b/datalad_registry_client/announce_update.py
@@ -1,0 +1,48 @@
+import logging
+
+import requests
+
+from datalad.distribution.dataset import datasetmethod
+from datalad.interface.base import Interface
+from datalad.interface.base import build_doc
+from datalad.interface.results import get_status_dict
+from datalad.interface.utils import eval_results
+
+from datalad_registry_client import opts
+
+lgr = logging.getLogger("datalad.registry.announce_update")
+
+
+@build_doc
+class RegistryAnnounceUpdate(Interface):
+    """Announce that dataset accessible via URL has been updated.
+
+    This maps to
+
+      PATCH /datasets/{ds_id}/urls/{url_encoded}
+    """
+
+    _params_ = opts.common_params
+
+    @staticmethod
+    @datasetmethod(name="registry_announce_update")
+    @eval_results
+    def __call__(dataset=None, sibling=None, url=None, endpoint=None):
+        # TODO: Allow recursive operation?
+        options = opts.process_args(
+            dataset=dataset, sibling=sibling, url=url, endpoint=endpoint)
+        res_base = get_status_dict(action="registry-announce-update",
+                                   logger=lgr, **options)
+
+        base_url = f"{options['endpoint']}/datasets"
+        try:
+            resp = requests.patch(
+                f"{base_url}/{options['ds_id']}/urls/{options['url_encoded']}",
+                timeout=1)
+            resp.raise_for_status()
+        except requests.exceptions.RequestException as exc:
+            yield dict(res_base, status="error",
+                       message=("Announcing update failed: %s", exc))
+            return
+        assert resp.status_code == 202, "bug in response expectations"
+        yield dict(res_base, status="ok", message="Announced update")

--- a/datalad_registry_client/opts.py
+++ b/datalad_registry_client/opts.py
@@ -1,0 +1,70 @@
+"""Common parameters and option handling.
+"""
+
+from datalad.distribution.dataset import EnsureDataset
+from datalad.distribution.dataset import require_dataset
+from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import EnsureStr
+from datalad.support.param import Parameter
+
+from datalad_registry.utils import url_encode
+
+common_params = dict(
+    dataset=Parameter(
+        args=("-d", "--dataset"),
+        doc="""dataset to operate on.  If no dataset is given, an
+        attempt is made to identify the dataset based on the current
+        working directory.""",
+        constraints=EnsureDataset() | EnsureNone()),
+    endpoint=Parameter(
+        args=("--endpoint",),
+        metavar="URL",
+        doc="""DataLad Registry instance to use (no trailing slash).
+        This defaults to the datalad_registry.endpoint option, if set,
+        or http://127.0.0.1:5000/v1 otherwise.""",
+        constraints=EnsureStr() | EnsureNone()),
+    sibling=Parameter(
+        args=("-s", "--sibling",),
+        metavar="NAME",
+        doc="""name of the sibling accessible via the URL. If not
+        given, the local dataset is assumed to be accessible via the
+        URL specified with [CMD: --url CMD][PY: `url` PY].""",
+        constraints=EnsureStr() | EnsureNone()),
+    url=Parameter(
+        args=("--url",),
+        doc="""URL to register.  This option is required unless a
+        sibling is specified, in which case remote.<name>.url is used
+        by default.""",
+        constraints=EnsureStr() | EnsureNone()))
+
+
+def process_args(*, dataset=None, sibling=None, url=None, endpoint=None):
+    """Process common arguments, returning dict with resolved/derived values.
+    """
+    ds = require_dataset(dataset, purpose="interact with a registry",
+                         check_installed=True)
+    repo = ds.repo
+    ds_id = ds.id
+    if not ds_id:
+        raise ValueError("Dataset does not have datalad.dataset.id set: {}"
+                         .format(ds.path))
+
+    if sibling:
+        remotes = repo.get_remotes()
+        if sibling not in remotes:
+            raise ValueError("Unknown sibling: {}".format(sibling))
+
+    if not url:
+        if not sibling:
+            raise ValueError(
+                "Must specify URL to use when sibling isn't given")
+        url = repo.config.get("remote.{}.url".format(sibling))
+        if not url:
+            raise ValueError("Could not find URL for {}".format(sibling))
+
+    endpoint = endpoint or repo.config.get(
+        "datalad_registry.endpoint",
+        "http://127.0.0.1:5000/v1")
+    return dict(ds=ds, ds_id=ds_id,
+                sibling=sibling, url=url, url_encoded=url_encode(url),
+                endpoint=endpoint)

--- a/datalad_registry_client/submit.py
+++ b/datalad_registry_client/submit.py
@@ -1,0 +1,115 @@
+
+import logging
+
+import requests
+
+from datalad.consts import PRE_INIT_COMMIT_SHA
+from datalad.distribution.dataset import datasetmethod
+
+from datalad.interface.base import Interface
+from datalad.interface.base import build_doc
+from datalad.interface.results import get_status_dict
+from datalad.interface.utils import eval_results
+
+from datalad_registry_client import opts
+
+lgr = logging.getLogger("datalad.registry.submit")
+
+
+@build_doc
+class RegistrySubmit(Interface):
+    """Submit a new URL to a DataLad Registry instance.
+
+    This handles the following steps:
+
+      - Retrieve a challenge token for a URL that provides this
+        dataset.  The URL may expose either the local repository or a
+        sibling.
+
+        GET /datasets/{dsid}/urls/{url_encoded}/token
+
+      - Create a ref for the token in the local or sibling repository.
+
+      - Register new URL.
+
+        POST /datasets/{dsid}/urls
+    """
+
+    _params_ = opts.common_params
+
+    @staticmethod
+    @datasetmethod(name="registry_submit")
+    @eval_results
+    def __call__(dataset=None, sibling=None, url=None, endpoint=None):
+        # TODO: Allow recursive operation?
+        options = opts.process_args(
+            dataset=dataset, sibling=sibling, url=url, endpoint=endpoint)
+        ds = options["ds"]
+        repo = ds.repo
+        ds_id = options["ds_id"]
+
+        res_base = get_status_dict(action="registry-submit",
+                                   logger=lgr, **options)
+
+        base_url = f"{options['endpoint']}/datasets"
+
+        try:
+            r_url = requests.get(
+                f"{base_url}/{ds_id}/urls/{options['url_encoded']}",
+                timeout=1)
+            r_url.raise_for_status()
+        except requests.exceptions.RequestException as exc:
+            yield dict(res_base, status="error",
+                       message=("Check if URL is known failed: %s", exc))
+            return
+        url_info = r_url.json()
+        if url_info.get("status") != "unknown":
+            yield dict(res_base, status="notneeded",
+                       message="URL already known to registry")
+            return
+
+        # Get token.
+        try:
+            r_token = requests.get(
+                f"{base_url}/{ds_id}/urls/{options['url_encoded']}/token",
+                timeout=1)
+            r_token.raise_for_status()
+        except requests.exceptions.RequestException as exc:
+            yield dict(res_base, status="error",
+                       message=("Getting token failed: %s", exc))
+            return
+
+        # Add token ref.
+        d_token = r_token.json()
+        try:
+            ref = d_token["ref"]
+            token = d_token["token"]
+        except KeyError as exc:
+            yield dict(res_base, status="error",
+                       message=("Invalid token response: %s", exc))
+            return
+        yield dict(res_base, status="ok", message="Retrieved token",
+                   token=token, ref=ref)
+
+        if sibling:
+            repo.call_git(["push", sibling,
+                           "{}:{}".format(PRE_INIT_COMMIT_SHA, ref)])
+            ref_msg = ("Created token ref via push to %s", sibling)
+        else:
+            repo.update_ref(ref, PRE_INIT_COMMIT_SHA)
+            ref_msg = "Created token ref"
+        yield dict(res_base, status="ok", token=token, ref=ref,
+                   message=ref_msg)
+
+        # Register URL.
+        try:
+            r_post = requests.post(f"{base_url}/{ds_id}/urls",
+                                   json=d_token, timeout=1)
+            r_post.raise_for_status()
+        except requests.exceptions.RequestException as exc:
+            yield dict(res_base, status="error",
+                       message=("Adding URL failed: %s", exc))
+            return
+        yield dict(res_base, status="ok",
+                   location=r_post.headers["Location"],
+                   message=("Registered URL: %s", options["url"]))

--- a/datalad_registry_client/tests/test_announce_update.py
+++ b/datalad_registry_client/tests/test_announce_update.py
@@ -1,0 +1,51 @@
+import pytest
+import requests
+import time
+
+import datalad.api as dl
+from datalad.tests.utils import assert_in_results
+
+from datalad_registry.utils import url_encode
+
+ENDPOINT = "http://127.0.0.1:5000/v1"
+
+
+@pytest.mark.devserver
+@pytest.mark.slow
+def test_announce_unknown(tmp_path):
+    ds = dl.Dataset(tmp_path / "ds").create()
+    assert_in_results(
+        ds.registry_announce_update(url=ds.path, on_failure="ignore"),
+        action="registry-announce-update", type="dataset",
+        path=ds.path, status="error")
+
+
+@pytest.mark.devserver
+@pytest.mark.slow
+def test_submit_and_announce(tmp_path):
+    ds = dl.Dataset(tmp_path / "ds").create()
+    ds_id = ds.id
+
+    url_encoded = url_encode(ds.path)
+    query_url = f"{ENDPOINT}/datasets/{ds_id}/urls/{url_encoded}"
+
+    assert_in_results(
+        ds.registry_submit(url=ds.path),
+        action="registry-submit", type="dataset",
+        path=ds.path, status="ok")
+
+    t_initial = time.time()
+    for i in range(10):
+        if requests.get(query_url).json()["status"] == "known":
+            break
+        time.sleep(0.1)
+    else:
+        t_final = time.time()
+        raise AssertionError(
+            "Submitted URL still not known after waiting ~{:03.2f} seconds"
+            .format(t_final - t_initial))
+
+    assert_in_results(
+        ds.registry_announce_update(url=ds.path),
+        action="registry-announce-update", type="dataset",
+        path=ds.path, status="ok")

--- a/datalad_registry_client/tests/test_submit.py
+++ b/datalad_registry_client/tests/test_submit.py
@@ -1,0 +1,109 @@
+import pytest
+import requests
+import subprocess as sp
+
+import datalad.api as dl
+from datalad.tests.utils import assert_in_results
+
+from datalad_registry.utils import url_encode
+
+ENDPOINT = "http://127.0.0.1:5000/v1"
+
+
+@pytest.mark.slow
+def test_submit_not_dataset(tmp_path):
+    sp.run(["git", "init"], cwd=str(tmp_path))
+    ds = dl.Dataset(tmp_path)
+    with pytest.raises(ValueError):
+        ds.registry_submit()
+
+
+@pytest.mark.devserver
+@pytest.mark.slow
+def test_submit_via_local(tmp_path):
+
+    ds = dl.Dataset(tmp_path / "ds").create()
+    ds_id = ds.id
+
+    url_encoded = url_encode(ds.path)
+    query_url = f"{ENDPOINT}/datasets/{ds_id}/urls/{url_encoded}"
+
+    assert requests.get(query_url).json()["status"] == "unknown"
+
+    # If sibling is not specified, URL is required.
+    with pytest.raises(ValueError):
+        ds.registry_submit()
+
+    assert_in_results(
+        ds.registry_submit(url=ds.path),
+        action="registry-submit", type="dataset",
+        location=query_url,
+        path=ds.path, status="ok")
+
+    assert requests.get(query_url).json()["status"] != "unknown"
+
+    # Redoing leads to notneeded.
+    assert_in_results(
+        ds.registry_submit(url=ds.path),
+        action="registry-submit", type="dataset",
+        path=ds.path, status="notneeded")
+
+
+@pytest.mark.slow
+def test_submit_invalid_siblings(tmp_path):
+    ds = dl.Dataset(tmp_path).create()
+
+    # Unknown sibling fails.
+    with pytest.raises(ValueError):
+        ds.registry_submit(sibling="foo")
+
+    # So does a sibling without a URL.
+    ds.config.set("remote.no_url.fetch", "blah", where="local")
+    with pytest.raises(ValueError):
+        ds.registry_submit(sibling="no_url")
+
+
+@pytest.mark.devserver
+@pytest.mark.slow
+def test_submit_via_sibling(tmp_path):
+    ds_sib = dl.Dataset(tmp_path / "sib").create()
+    ds = dl.clone(ds_sib.path, str(tmp_path / "clone"))
+    ds_id = ds.id
+
+    url_encoded = url_encode(ds_sib.path)
+    query_url = f"{ENDPOINT}/datasets/{ds_id}/urls/{url_encoded}"
+
+    assert requests.get(query_url).json()["status"] == "unknown"
+
+    assert_in_results(
+        ds.registry_submit(sibling="origin"),
+        action="registry-submit", type="dataset",
+        location=query_url,
+        path=ds.path, status="ok")
+
+    assert requests.get(query_url).json()["status"] != "unknown"
+
+
+@pytest.mark.devserver
+@pytest.mark.slow
+def test_submit_explicit_endpoint(tmp_path):
+    ds = dl.Dataset(tmp_path / "ds").create()
+    ds_id = ds.id
+
+    # Invalid.
+    assert_in_results(
+        ds.registry_submit(url=ds.path, endpoint="abc", on_failure="ignore"),
+        action="registry-submit", type="dataset",
+        path=ds.path, status="error")
+
+    # Valid, explicit.
+    url_encoded = url_encode(ds.path)
+    query_url = f"{ENDPOINT}/datasets/{ds_id}/urls/{url_encoded}"
+
+    assert_in_results(
+        ds.registry_submit(url=ds.path, endpoint=ENDPOINT),
+        action="registry-submit", type="dataset",
+        location=query_url,
+        path=ds.path, status="ok")
+
+    assert requests.get(query_url).json()["status"] != "unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,6 @@ requires = ["setuptools >= 30.3.0", "wheel"]
 
 [tool.pytest.ini_options]
 markers = [
+    "devserver: mark tests that require Flask development server",
     "slow: mark tests as slow",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,4 @@ packages = find:
 tests =
     coverage
     pytest
+    nose  # so that DataLad's test utils can be used with base install

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,2 @@
 from setuptools import setup
-setup()
+setup(entry_points={"datalad.extensions": ["registry=datalad_registry_client:command_suite"]})

--- a/up
+++ b/up
@@ -13,7 +13,22 @@ export FLASK_ENV=development
 
 mkdir -p "$DATALAD_REGISTRY_INSTANCE_PATH"
 python -m flask init-db
+docker-compose -f docker-compose.broker.yml pull
 docker-compose -f docker-compose.broker.yml up &
+
+broker_ok=
+for i in $(seq 30)
+do
+    echo "Checking for broker connection (try $i)..."
+    if ! nc -nvz 127.0.0.1 5672
+    then
+        sleep 1
+    else
+        broker_ok=1
+        break
+    fi
+done
+test -z "$broker_ok" && exit 1
 
 celery () {
     python -m celery -A datalad_registry.runcelery.celery "$@"
@@ -22,5 +37,20 @@ celery () {
 celery worker --loglevel "$DATALAD_REGISTRY_LOG_LEVEL" &
 celery beat --loglevel "$DATALAD_REGISTRY_LOG_LEVEL" \
        --schedule "$DATALAD_REGISTRY_INSTANCE_PATH"/celerybeat-schedule &
+
+celery_ok=
+for i in $(seq 10)
+do
+    echo "Checking celery status (try $i)..."
+    if celery status --timeout 1 --json | grep -q pong
+    then
+        echo "Celery node found"
+        celery_ok=1
+        break
+    else
+        sleep 5
+    fi
+done
+test -z "$celery_ok" && exit 1
 
 python -m flask run

--- a/up
+++ b/up
@@ -2,19 +2,21 @@
 
 set -eu
 
-: "${DATALAD_REGISTRY_DATASET_CACHE:=$PWD/instance/cache}"
+: "${DATALAD_REGISTRY_INSTANCE_PATH:=$PWD/instance}"
+export DATALAD_REGISTRY_INSTANCE_PATH
+: "${DATALAD_REGISTRY_DATASET_CACHE:=$DATALAD_REGISTRY_INSTANCE_PATH/cache}"
 export DATALAD_REGISTRY_DATASET_CACHE
 : "${DATALAD_REGISTRY_LOG_LEVEL:=DEBUG}"
 export DATALAD_REGISTRY_LOG_LEVEL
 export FLASK_APP=datalad_registry.factory:create_app
 export FLASK_ENV=development
 
-mkdir -p instance
+mkdir -p "$DATALAD_REGISTRY_INSTANCE_PATH"
 python -m flask init-db
 docker-compose -f docker-compose.broker.yml up &
 python -m celery -A datalad_registry.runcelery.celery worker \
        --loglevel "$DATALAD_REGISTRY_LOG_LEVEL" &
 python -m celery -A datalad_registry.runcelery.celery beat \
        --loglevel "$DATALAD_REGISTRY_LOG_LEVEL" \
-       --schedule instance/celerybeat-schedule &
+       --schedule "$DATALAD_REGISTRY_INSTANCE_PATH"/celerybeat-schedule &
 python -m flask run

--- a/up
+++ b/up
@@ -14,9 +14,13 @@ export FLASK_ENV=development
 mkdir -p "$DATALAD_REGISTRY_INSTANCE_PATH"
 python -m flask init-db
 docker-compose -f docker-compose.broker.yml up &
-python -m celery -A datalad_registry.runcelery.celery worker \
-       --loglevel "$DATALAD_REGISTRY_LOG_LEVEL" &
-python -m celery -A datalad_registry.runcelery.celery beat \
-       --loglevel "$DATALAD_REGISTRY_LOG_LEVEL" \
+
+celery () {
+    python -m celery -A datalad_registry.runcelery.celery "$@"
+}
+
+celery worker --loglevel "$DATALAD_REGISTRY_LOG_LEVEL" &
+celery beat --loglevel "$DATALAD_REGISTRY_LOG_LEVEL" \
        --schedule "$DATALAD_REGISTRY_INSTANCE_PATH"/celerybeat-schedule &
+
 python -m flask run

--- a/up-tests
+++ b/up-tests
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eu
+
+echo "pgid: $$"  # for easy clean-up
+
+ipath=$(mktemp -d "${TMPDIR:-/tmp}"/dl-registry-tests-XXXX)
+: "${DATALAD_REGISTRY_INSTANCE_PATH:=$ipath}"
+export DATALAD_REGISTRY_INSTANCE_PATH
+logfile="$ipath/up.log"
+echo "Dumping ./up output to $logfile"
+
+./up >"$logfile" 2>&1 &
+
+for i in $(seq 30)
+do
+    echo "Checking for Flask server connection (try $i)..."
+    if ! nc -nvz 127.0.0.1 5000
+    then
+        sleep 5
+    else
+        exit 0
+    fi
+done
+
+exit 1


### PR DESCRIPTION
~This is a draft (at the very least needs tests)~ This series is work towards gh-8.  At the moment it has functional subcommands for registering a new URL and for announcing an update, which I think is a good stopping point.

The beginning of the series is mostly concerned with reworking the `up` script so that it can be used reliably in the context of automated tests.  (Before this point, the `app_instance` and `client` fixtures were sufficient.)
