### PR TITLE
Make pytest error on warnings, ignoring deprecation warning from future

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,9 @@ commands =
 
 [pytest]
 addopts = --ignore=instance
+filterwarnings =
+    error
+    ignore::DeprecationWarning:future
 markers =
     devserver: mark tests that require Flask development server
     slow: mark tests as slow


### PR DESCRIPTION
About the ignored warning: datalad imports annexremote, which imports future, which imports imp, which is deprecated in favor of importlib.  I can't find future's repository or bug tracker (as the "Fork me on GitHub" link in its docs doesn't work), so I don't know if or when they're going to address this warning.  However, the latest (unreleased) code in annexremote's repository drops the dependency on future, so by the time the next version of annexremote gets released, the warning will go away.