### PR TITLE
Move entry points declaration to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,10 @@ install_requires =
     psycopg2-binary ~= 2.7
 packages = find:
 
+[options.entry_points]
+datalad.extensions =
+    registry = datalad_registry_client:command_suite
+
 [options.extras_require]
 tests =
     coverage

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,3 @@
 from setuptools import setup
 
-setup(
-    entry_points={
-        "datalad.extensions": ["registry=datalad_registry_client:command_suite"],
-    },
-)
+setup()


### PR DESCRIPTION
In order to keep all of the packaging information together in one file.