### PR TITLE
Provide __version__ for datalad_registry_client

### DIFF
--- a/datalad_registry_client/__init__.py
+++ b/datalad_registry_client/__init__.py
@@ -1,3 +1,5 @@
+import sys
+
 command_suite = (
     "Interact with DataLad registry",
     [
@@ -15,3 +17,10 @@ command_suite = (
         ),
     ],
 )
+
+if sys.version_info[:2] < (3, 8):
+    from importlib_metadata import version
+else:
+    from importlib.metadata import version
+
+__version__ = version("datalad-registry")


### PR DESCRIPTION
ATM it is not installed as an independent python module, so would just
reuse datalad-registry I guess for the version.  With this

   datalad wtf -S extensions

would provide proper version