### PR TITLE
Update codecov action to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install wheel
-        pip install codecov
+        pip install coverage
         pip install mypy types-requests
         pip install .[tests]
     - name: Set up dev server
@@ -50,4 +50,4 @@ jobs:
     - name: mypy check
       run: mypy datalad_registry datalad_registry_client
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2


### PR DESCRIPTION
Version 1 of codecov's GitHub action is [deprecated](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1) and will start experiencing brownouts soon, and they advise updating to v2.