### PR TITLE
Extend metadata extracted from git-annex

### DIFF
--- a/datalad_registry/models.py
+++ b/datalad_registry/models.py
@@ -14,6 +14,8 @@ class URL(db.Model):  # type: ignore
     ds_id = db.Column(db.Text, nullable=True)
     annex_uuid = db.Column(db.Text)
     annex_key_count = db.Column(db.Integer)
+    annexed_files_in_wt_count = db.Column(db.Integer)
+    annexed_files_in_wt_size = db.Column(db.Text)
     info_ts = db.Column(db.DateTime(timezone=True))
     update_announced = db.Column(db.Boolean, default=False, nullable=False)
     head = db.Column(db.Text)

--- a/datalad_registry/overview.py
+++ b/datalad_registry/overview.py
@@ -50,6 +50,8 @@ def overview():  # No type hints due to mypy#7187.
                 "annex_key_count",
                 "head",
                 "head_describe",
+                'annexed_files_in_wt_count',
+                'annexed_files_in_wt_size',
                 "git_objects_kb",
             ]:
                 row[col] = getattr(info, col)

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -38,6 +38,8 @@ href="{{ url_for('.overview', sort=sort_by, filter=url_filter,
             <th>Dataset</th>
             <th>Commit</th>
             <th><a {{ sort_href('keys-desc', 'keys-asc') }}>Annex keys</a></th>
+            <th>Annexed files in working tree</th>
+            <th>Size of Annexed files in working tree (bytes)</th>
             <th><a {{ sort_href('update-desc', 'update-asc') }}>Last update</a></th>
             <th>.git/objects Size (KiB)</th>
           </tr>
@@ -49,6 +51,8 @@ href="{{ url_for('.overview', sort=sort_by, filter=url_filter,
               else r["head"]|truncate(9, False, "")
               if r["head"] }}</td>
             <td>{{ r["annex_key_count"] if r["annex_key_count"] is not none }}</td>
+            <td>{{ r["annexed_files_in_wt_count"] }}</td>
+            <td>{{ r["annexed_files_in_wt_size"] }}</td>
             <td>{{ r["last_update"] if r["last_update"] }}</td>
             <td>{{ r["git_objects_kb"] if r["git_objects_kb"] is not none }}</td>
           </tr>


### PR DESCRIPTION
Count and size of annexed files in working tree are now extracted and included in web UI.