### PR TITLE
Fix:  Solved the problem of cloned datasets not being stored in cache

### DIFF
--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -137,9 +137,15 @@ def collect_dataset_uuid(url: str) -> None:
     info["ds_id"] = ds_id
     info["processed"] = True
     result.update(info)
+
+    # Ensure the existence of the containing directory of
+    # the destination of the cloned dataset
     abbrev_id = "None" if ds_id is None else ds_id[:3]
+    cache_dir_level1 = cache_dir / abbrev_id
+    cache_dir_level1.mkdir(parents=True, exist_ok=True)
+
     try:
-        ds_path.rename(cache_dir / abbrev_id / url_encode(url))
+        ds_path.rename(cache_dir_level1 / url_encode(url))
     except OSError as e:
         if e.errno == errno.ENOTEMPTY:
             lgr.debug("Clone of %s already in cache", url)

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -109,9 +109,9 @@ def _extract_annex_info(repo) -> InfoType:
         info["annexed_files_in_wt_count"] = working_tree_record[
             "annexed files in working tree"
         ]
-        info["annexed_files_in_wt_size"] = working_tree_record[
-            "size of annexed files in working tree"
-        ]
+        info["annexed_files_in_wt_size"] = int(
+            working_tree_record["size of annexed files in working tree"]
+        )
 
     return info
 

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,10 @@ exclude = .*/,build/,dist/,instance/,venv/
 hang-closing = False
 max-doc-length = 88
 max-line-length = 88
+
+# Allow whitespace before ':' to avoid conflict with the default behavior of Black
 extend-ignore = E203
+
 unused-arguments-ignore-stub-functions = True
 select = C,B,B902,B950,E,E242,F,I,U100,W
 ignore = B005,E203,E262,E266,E501,I201,W503


### PR DESCRIPTION
By ensuring the existence of the containing directory of the destination of any cloned dataset, a clone dataset can now be store in the cache directory.