### PR TITLE
 Ensure Celery tasks receive arguments in correct type

### DIFF
--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from shutil import rmtree
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import validate_arguments
+from pydantic import StrictStr, validate_arguments
 
 from datalad_registry import celery
 from datalad_registry.models import URL, db
@@ -164,7 +164,9 @@ def collect_dataset_uuid(url: str) -> None:
 
 @celery.task
 @validate_arguments
-def collect_dataset_info(datasets: Optional[List[Tuple[str, str]]] = None) -> None:
+def collect_dataset_info(
+    datasets: Optional[List[Tuple[StrictStr, StrictStr]]] = None
+) -> None:
     """Collect information about `datasets`.
 
     Parameters

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from shutil import rmtree
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from pydantic import validate_arguments
+
 from datalad_registry import celery
 from datalad_registry.models import URL, db
 from datalad_registry.utils import url_encode
@@ -117,6 +119,7 @@ def _extract_annex_info(repo) -> InfoType:
 
 
 @celery.task
+@validate_arguments
 def collect_dataset_uuid(url: str) -> None:
     from flask import current_app
 
@@ -160,6 +163,7 @@ def collect_dataset_uuid(url: str) -> None:
 
 
 @celery.task
+@validate_arguments
 def collect_dataset_info(datasets: Optional[List[Tuple[str, str]]] = None) -> None:
     """Collect information about `datasets`.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     importlib-metadata; python_version < "3.8"
     SQLAlchemy
     psycopg2-binary ~= 2.7
+    pydantic >= 1.10
 packages = find:
 
 [options.entry_points]


### PR DESCRIPTION
Utilize @validate_arguments from Pydantic to ensure arguments of Celery tasks are received in their intended types, not corrupted by the transmission in JSON.

This PR fixes the problem of sending a celery task with an argument of a tuple, but the responding celery worker receiving an argument of a list.