### PR TITLE
Update the minimum support Python version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         pip install --upgrade pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.9
 install_requires =
     celery >= 5.0
     click


### PR DESCRIPTION
As discussed with Yarik, the minimum supported Python version of the project is set to 3.9. This PR simply update the setup configurations and GitHub action workflows to implement this agreed change.