### PR TITLE
Restrict SQLAlchemy to version before 2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     Flask
     Flask-SQLAlchemy
     importlib-metadata; python_version < "3.8"
-    SQLAlchemy
+    SQLAlchemy >= 1.4, < 2.0
     psycopg2-binary ~= 2.7
     pydantic >= 1.10
 packages = find:


### PR DESCRIPTION
The latest SQLAlchemy, version 2.0, 01-26-2023, is currently incompatible with our project. Let's restrict the version of SQLAlchemy to before 2.0 for now.