### PR TITLE
Prevent Black from upgrading to incompatible version automatically

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,4 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --diff --verbose"
+          version: "~= 22.12.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ tests =
 dev =
     %(tests)s
     tox>=3.0
-    black>=22.0
+    black >= 22.0, < 23.0
 
 [mypy]
 ignore_missing_imports = True


### PR DESCRIPTION
Upgrading to incompatible version should be done manually.