### PR TITLE
Modify broker container specifications

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     environment:
       <<: *env
     ports:
-      - "5672:5672"
+      - "127.0.0.1:5672:5672"  # AMQP
     expose:
       - "5672"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,8 @@ services:
       DATALAD_REGISTRY_POSTGRES_HOST: db
       FLASK_APP: datalad_registry.factory:create_app
       FLASK_ENV: development
-      RABBITMQ_DEFAULT_PASS:
-      RABBITMQ_DEFAULT_USER: user
-      RABBITMQ_DEFAULT_VHOST: /
+      RABBITMQ_DEFAULT_USER: "user"
+      RABBITMQ_DEFAULT_PASS: "$RABBITMQ_DEFAULT_PASS"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
     command: [sh, -c, "flask init-db && flask run --host=0.0.0.0"]
     volumes:
@@ -28,7 +27,8 @@ services:
   broker:
     image: rabbitmq:3-alpine
     environment:
-      <<: *env
+      RABBITMQ_DEFAULT_USER: "user"
+      RABBITMQ_DEFAULT_PASS: "$RABBITMQ_DEFAULT_PASS"
     ports:
       - "127.0.0.1:5672:5672"  # AMQP
     expose:


### PR DESCRIPTION
This PR changes few specs for the Celery broker:

1. Set a password
2. For security, restrict access to localhost only
3. Expose only the relevant environment variables