### PR TITLE
BF: Handle IncompleteResultsError in cloning dataset

### DIFF
--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -3,7 +3,6 @@ import errno
 import logging
 from pathlib import Path
 from shutil import rmtree
-import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from celery import group
@@ -38,9 +37,6 @@ def clone_dataset(url: str, ds_path: Path) -> Any:
         max_incomplete_results_errs = 5
         incomplete_results_err_count = 0
 
-        # Seconds to wait before retrying in case of IncompleteResultsError
-        retry_lapse = 1
-
         # Clone the dataset @ url into ds_path
         while True:
             try:
@@ -51,8 +47,6 @@ def clone_dataset(url: str, ds_path: Path) -> Any:
                 incomplete_results_err_count += 1
                 if incomplete_results_err_count > max_incomplete_results_errs:
                     raise
-                else:
-                    time.sleep(retry_lapse)
             else:
                 break
 

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -41,11 +41,20 @@ def clone_dataset(url: str, ds_path: Path) -> Any:
         while True:
             try:
                 ds = dl.clone(url, ds_path_str)
-            except IncompleteResultsError:
-                lgr.warning(f"Incomplete results error in cloning {url}. Trying again.")
+            except Exception as e:
+                # If failed cloning attempt created a directory, remove it
+                if ds_path.exists():
+                    rmtree(ds_path)
 
-                incomplete_results_err_count += 1
-                if incomplete_results_err_count > max_incomplete_results_errs:
+                if isinstance(e, IncompleteResultsError):
+                    lgr.warning(
+                        f"IncompleteResultsError in cloning {url}. Trying again."
+                    )
+
+                    incomplete_results_err_count += 1
+                    if incomplete_results_err_count > max_incomplete_results_errs:
+                        raise
+                else:
                     raise
             else:
                 break


### PR DESCRIPTION
Cloning a dataset sometimes can fail with an IncompleteResultsError. Simply retrying will resolve the problem in most cases.

This PR is only a step toward a solution for https://github.com/datalad/datalad-registry/issues/93. A complete solution would require the handling of the case in which all retries of cloning fail. However, with this PR, the population of datasets would be stable enough for the work for https://github.com/datalad/datalad-registry/issues/89 to start.