### PR TITLE
Replace psycopg2-binary with psycopg2 as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ datalad==0.18.0
 Flask==2.2.2
 Flask-SQLAlchemy==3.0.2
 SQLAlchemy==1.4.46
-psycopg2-binary==2.9.5
+psycopg2==2.9.5
 pydantic==1.10.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     Flask-SQLAlchemy
     importlib-metadata; python_version < "3.8"
     SQLAlchemy >= 1.4, < 2.0
-    psycopg2-binary ~= 2.7
+    psycopg2 >= 2.9, < 3.0
     pydantic >= 1.10
 packages = find:
 


### PR DESCRIPTION
psycopg2-binary is not meant to be used as a dependency of a published package. For details, please see
https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary. Using psycopg2-binary actually caused a failure in communication with Postgres in the container built based on the Debian image.