### PR TITLE
Use bind mounts instead of named volumes

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -93,8 +93,13 @@ services:
       POSTGRES_INITDB_ARGS: --encoding utf8 --locale C
     expose:
         - "5432"
+    userns_mode: "keep-id"  # This has an effect only after podman-compose 1.0.3 possibly
+                            # See https://github.com/containers/podman-compose/issues/166
+                            # for details.
+                            # For podman-compose 1.0.3 or earlier, use
+                            # `PODMAN_USERNS=keep-id podman-compose up`
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - ${DL_REGISTRY_DB_DATA_PATH}:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "dlreg"]
       interval: 7s
@@ -103,5 +108,4 @@ services:
 
 
 volumes:
-  db-data:
   instance-data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,7 @@ services:
 
     command: [sh, -c, "flask init-db && flask run --host=0.0.0.0"]
     volumes:
-      - instance-data:/app/instance
+      - ${DL_REGISTRY_INSTANCE_PATH}:/app/instance
 
   worker:
     build: .
@@ -40,7 +40,7 @@ services:
         condition: service_healthy
     command: [celery, -A, datalad_registry.runcelery.celery, worker, --loglevel, DEBUG, --pool, prefork]
     volumes:
-      - instance-data:/app/instance
+      - ${DL_REGISTRY_INSTANCE_PATH}:/app/instance
     environment:
       <<: *env
     healthcheck:
@@ -61,7 +61,7 @@ services:
       -s, /app/instance/celerybeat-schedule
     ]
     volumes:
-      - instance-data:/app/instance
+      - ${DL_REGISTRY_INSTANCE_PATH}:/app/instance
     environment:
       <<: *env
 
@@ -105,7 +105,3 @@ services:
       interval: 7s
       timeout: 3s
       retries: 5
-
-
-volumes:
-  instance-data:


### PR DESCRIPTION
Use bind mounts instead of named volumes for easy of allocation of resources in the host machine.