### PR TITLE
Unique urls

### DIFF
--- a/tools/populate.py
+++ b/tools/populate.py
@@ -97,7 +97,9 @@ def populate(start: Optional[int], stop: Optional[int]) -> None:
     ]
 
     # Build clone URLs for active GitHub datasets
-    active_github_dataset_urls = [ds.url + ".git" for ds in active_github_datasets]
+    active_github_dataset_urls = list(
+        {ds.url + ".git" for ds in active_github_datasets}
+    )
 
     # Select URLs of active GitHub datasets to submit
     s = slice(start, stop)


### PR DESCRIPTION
Ensure the URLs submitted by each run of the `population.py` script are unique. This is useful in getting the actual number of datasets to be handled by the datalad registry instance.