### PR TITLE
Use dict to preserve order of retrieved URLs for population

### DIFF
--- a/tools/populate.py
+++ b/tools/populate.py
@@ -98,7 +98,7 @@ def populate(start: Optional[int], stop: Optional[int]) -> None:
 
     # Build clone URLs for active GitHub datasets
     active_github_dataset_urls = list(
-        {ds.url + ".git" for ds in active_github_datasets}
+        {ds.url + ".git": None for ds in active_github_datasets}
     )
 
     # Select URLs of active GitHub datasets to submit


### PR DESCRIPTION
While [dictionaries are insertion ordered](https://stackoverflow.com/a/39980744/4635580), sets are not. It is better to use a dictionary to preserve the order of dataset URLs read from the usage dashboard so that we get the URLs for submission to the Datalad registry instance in a consistent order across multiple runs of the `population.py` script. 