### PR TITLE
Remove customized table name

### DIFF
--- a/datalad_registry/models.py
+++ b/datalad_registry/models.py
@@ -8,9 +8,6 @@ migrate = Migrate()
 
 
 class URL(db.Model):  # type: ignore
-
-    __tablename__ = "urls"
-
     id = db.Column(db.Integer, primary_key=True, nullable=False)
     url = db.Column(db.Text, nullable=False, unique=True)
     ds_id = db.Column(db.Text, nullable=True)

--- a/migrations/versions/769fc6a4d2ea_removing_customized___tablename___urls_.py
+++ b/migrations/versions/769fc6a4d2ea_removing_customized___tablename___urls_.py
@@ -1,0 +1,22 @@
+"""Removing customized __tablename__ urls, and let URL model to assume default name
+
+Revision ID: 769fc6a4d2ea
+Revises:
+Create Date: 2023-03-10 17:30:48.983791
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "769fc6a4d2ea"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.rename_table("urls", "url")
+
+
+def downgrade():
+    op.rename_table("url", "urls")


### PR DESCRIPTION
[`__tablename__` doesn't need to be defined when using Flask-SQLAlchemy's model](https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/models/#defining-models). Let's remove the customized table name and adopt the naming convention implemented by Flask-SQLAlchemy.

