### PR TITLE
Specify isort and flake8 as dev dependencies

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@ pytest-cov==4.0.0
 tox==3.28.0
 black[d]==22.12.0
 pre-commit==2.21.0
+flake8==6.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,4 @@ tox==3.28.0
 black[d]==22.12.0
 pre-commit==2.21.0
 flake8==6.0.0
+isort==5.11.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ dev =
     %(tests)s
     tox>=3.0
     black >= 22.0, < 23.0
+    flake8 >= 6.0, < 7.0
 
 [mypy]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ dev =
     tox>=3.0
     black >= 22.0, < 23.0
     flake8 >= 6.0, < 7.0
+    isort >= 5.11.4, < 6.0
 
 [mypy]
 ignore_missing_imports = True


### PR DESCRIPTION
The project already uses isort and flake8 in pre-commit and GitHub workflows. This PR specifies them as dev requirements in `setup.cfg` and `requirements_dev.txt`