### PR TITLE
Add docker as a dependency

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,3 +6,4 @@ black[d]==22.12.0
 pre-commit==2.21.0
 flake8==6.0.0
 isort==5.11.4
+docker==6.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ tests =
     coverage>=7.0
     pytest>=7.0
     pytest-cov>=4.0
+    docker~=6.0
 
 dev =
     %(tests)s


### PR DESCRIPTION
By adding this dependency, we can utilize [Docker Engine API](https://docs.docker.com/engine/api/) for testing and development in Python.