### PR TITLE
Relax Flask-Migrate version restriction

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     SQLAlchemy >= 1.4, < 2.0
     psycopg2 >= 2.9, < 3.0
     pydantic >= 1.10
-    Flask-Migrate ~= 4.0.4
+    Flask-Migrate ~= 4.0
 packages = find:
 
 [options.entry_points]


### PR DESCRIPTION
Relax Flask-Migrate version restriction so that all sub-versions of version 4 are allowed.