### PR TITLE
Enable testing mode for the Datalad-registry Flask app in tests

### DIFF
--- a/datalad_registry/tests/test_new_organization/conftest.py
+++ b/datalad_registry/tests/test_new_organization/conftest.py
@@ -34,6 +34,7 @@ def flask_app(monkeypatch, tmp_path):
                 password=os.environ["DATALAD_REGISTRY_PASSWORD"],
             )
         ),
+        "TESTING": True,
     }
 
     app = create_app(test_config)


### PR DESCRIPTION
This PR is based on https://github.com/datalad/datalad-registry/pull/138. It should be rebased after https://github.com/datalad/datalad-registry/pull/138 is merged to get the relevant commits of this PR.