### PR TITLE
Sort with NULL values at the end of the result

### DIFF
--- a/datalad_registry/overview.py
+++ b/datalad_registry/overview.py
@@ -4,6 +4,7 @@
 import logging
 
 from flask import Blueprint, render_template, request
+from sqlalchemy import nullslast
 
 from datalad_registry.models import URL, db
 
@@ -59,7 +60,7 @@ def overview():  # No type hints due to mypy#7187.
         lgr.debug("Ignoring unknown sort parameter: %s", sort_by)
         sort_by = default_sort_scheme
     col, sort_method = _SORT_ATTRS[sort_by]
-    r = r.order_by(getattr(getattr(URL, col), sort_method)())
+    r = r.order_by(nullslast(getattr(getattr(URL, col), sort_method)()))
 
     # Get total number of URLs to be displayed through pagination
     num_urls = r.count()


### PR DESCRIPTION
This PR is intended to resolve https://github.com/datalad/datalad-registry/issues/132.

With the changes in this PR, all items with NULL values are allocated to the end of the result of a sort, regardless of the order of the sort, descending or ascending.

These changes have been made available in the running instance of Datalad-registry on Typhon