### PR TITLE
Redefine .git/objects size

### DIFF
--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -78,7 +78,9 @@ def get_info(ds_repo: Any) -> InfoType:
     info.update(_extract_annex_info(ds_repo))
     info["info_ts"] = datetime.now(timezone.utc)
     info["update_announced"] = False
-    info["git_objects_kb"] = ds_repo.count_objects["size"]
+    info["git_objects_kb"] = (
+        ds_repo.count_objects["size"] + ds_repo.count_objects["size-pack"]
+    )
     return info
 
 


### PR DESCRIPTION
Redefine `.git/objects` size as the sum of "size" and "size-pack" of `count_objects` of the dataset repo.

This PR is intended to resolve #135.

P.S. This new definition of `.git/objects` size has been applied to the running instance of Datalad-registry on Typhon.