### PR TITLE
Reimplement pagination

### DIFF
--- a/datalad_registry/overview.py
+++ b/datalad_registry/overview.py
@@ -11,7 +11,6 @@ from datalad_registry.models import URL, db
 lgr = logging.getLogger(__name__)
 bp = Blueprint("overview", __name__, url_prefix="/overview")
 
-_PAGE_NITEMS = 25  # TODO: Should eventually be configurable by app.
 _SORT_ATTRS = {
     "keys-asc": ("annex_key_count", "asc"),
     "keys-desc": ("annex_key_count", "desc"),
@@ -26,19 +25,6 @@ _SORT_ATTRS = {
     "git_objects_kb-asc": ("git_objects_kb", "asc"),
     "git_objects_kb-desc": ("git_objects_kb", "desc"),
 }
-
-# Columns of the table displayed on the overview page
-_COLS = [
-    "ds_id",
-    "url",
-    "annex_key_count",
-    "head",
-    "head_describe",
-    "annexed_files_in_wt_count",
-    "annexed_files_in_wt_size",
-    "git_objects_kb",
-    "metadata_",
-]
 
 
 @bp.get("/")
@@ -62,32 +48,12 @@ def overview():  # No type hints due to mypy#7187.
     col, sort_method = _SORT_ATTRS[sort_by]
     r = r.order_by(nullslast(getattr(getattr(URL, col), sort_method)()))
 
-    # Get total number of URLs to be displayed through pagination
-    num_urls = r.count()
-
     # Paginate
-    page = request.args.get("page", 1, type=int)
-    r = r.paginate(page=page, per_page=_PAGE_NITEMS, error_out=False)
-
-    # Generate rows
-    rows = []
-    for item in r.items:
-        row = {col: getattr(item, col) for col in _COLS}
-
-        ts = item.info_ts
-        if ts is not None:
-            row["last_update"] = ts.strftime("%Y-%m-%dT%H:%M:%S%z")
-        else:
-            row["last_update"] = None
-        rows.append(row)
+    pagination = r.paginate()
 
     return render_template(
         "overview.html",
-        rows=rows,
-        page=page,
-        has_next=r.has_next,
-        has_prev=r.has_prev,
+        pagination=pagination,
         sort_by=sort_by,
         url_filter=url_filter,
-        num_urls=num_urls,
     )

--- a/datalad_registry/static/main.css
+++ b/datalad_registry/static/main.css
@@ -32,5 +32,4 @@ div#datalad-registry div.pager {
 
 div#datalad-registry div.pagination {
     padding-top: 0.5em;
-    font-size: 1.8em;
 }

--- a/datalad_registry/static/main.css
+++ b/datalad_registry/static/main.css
@@ -23,12 +23,13 @@ div#datalad-registry table.list td.mono {
     font-family: monospace;
 }
 
-div#datalad-registry table.pager {
+div#datalad-registry div.pager {
+    padding-top: 2em;
     margin-left: auto;
     margin-right: auto;
+    text-align: center;
 }
 
-div#datalad-registry table.pager td {
-    text-align: center;
-    width: 7em;
+div#datalad-registry div.pagination {
+    padding-top: 0.5em;
 }

--- a/datalad_registry/static/main.css
+++ b/datalad_registry/static/main.css
@@ -32,4 +32,5 @@ div#datalad-registry div.pager {
 
 div#datalad-registry div.pagination {
     padding-top: 0.5em;
+    font-size: 1.8em;
 }

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -15,12 +15,7 @@
     {% for page in pagination.iter_pages() %}
       {% if page %}
         {% if page != pagination.page %}
-          <a href="{{
-              url_for(endpoint, page=page, per_page=pagination.per_page, sort=sort_by, filter=url_filter)
-              }}"
-          >
-            {{ page }}
-          </a>
+          <a href="{{ url_for(endpoint, page=page, per_page=pagination.per_page, sort=sort_by, filter=url_filter) }}">{{ page }}</a>
         {% else %}
           <strong>{{ page }}</strong>
         {% endif %}

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -7,11 +7,6 @@
   href="{{ url_for('.overview', filter=url_filter, sort='{}'.format(new_sort)) }}"
 {%- endmacro -%}
 
-{%- macro page_href(page) -%}
-  href="{{ url_for('.overview', sort=sort_by, filter=url_filter,
-                 page='{}'.format(page)) }}"
-{%- endmacro -%}
-
 {% macro render_pagination_widget(pagination, endpoint) %}
   <div class="page-items">
     {{ pagination.first }} - {{ pagination.last }} of {{ pagination.total }}

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -20,7 +20,7 @@
     {% for page in pagination.iter_pages() %}
       {% if page %}
         {% if page != pagination.page %}
-          <a href="{{ url_for(endpoint, page=page) }}">{{ page }}</a>
+          <a href="{{ url_for(endpoint, page=page, per_page=pagination.per_page) }}">{{ page }}</a>
         {% else %}
           <strong>{{ page }}</strong>
         {% endif %}
@@ -80,21 +80,20 @@
           Metadata
         </th>
       </tr>
-      {%- for r in rows -%}
+      {%- for i in pagination -%}
         <tr>
-          <td><a href="{{ r["url"] }}">{{ r["url"] }}</a></td>
-          <td class="mono">{{ r["ds_id"] if r["ds_id"] is not none }}</td>
+          <td><a href="{{ i.url }}">{{ i.url }}</a></td>
+          <td class="mono">{{ i.ds_id if i.ds_id is not none }}</td>
           <td class="mono">
-            {{ r["head_describe"] if r["head_describe"] is not none
-                        else (r["head"]|truncate(9, False, "") if r["head"] is not none) }}
+            {{ i.head_describe if i.head_describe is not none }}
           </td>
-          <td>{{ r["annex_key_count"] if r["annex_key_count"] is not none }}</td>
-          <td>{{ r["annexed_files_in_wt_count"] if r["annexed_files_in_wt_count"] is not none }}</td>
-          <td>{{ r["annexed_files_in_wt_size"] if r["annexed_files_in_wt_size"] is not none }}</td>
-          <td>{{ r["last_update"] if r["last_update"] }}</td>
-          <td>{{ r["git_objects_kb"] if r["git_objects_kb"] is not none }}</td>
+          <td>{{ i.annex_key_count if i.annex_key_count is not none }}</td>
+          <td>{{ i.annexed_files_in_wt_count if i.annexed_files_in_wt_count is not none }}</td>
+          <td>{{ i.annexed_files_in_wt_size if i.annexed_files_in_wt_size is not none }}</td>
+          <td>{{ i.info_ts.strftime("%Y-%m-%dT%H:%M:%S%z") if i.info_ts is not none }}</td>
+          <td>{{ i.git_objects_kb if i.git_objects_kb is not none }}</td>
           <td>
-            {%- for data in r["metadata_"] -%}
+            {%- for data in i.metadata_ -%}
               <a href="{{ url_for('api.url_metadata', url_metadata_id=data.id) }}">
                 {{ data.extractor_name }}
               </a>

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -104,23 +104,9 @@
         </tr>
       {%- endfor -%}
     </table>
-    <table class="pager">
-      <tr>
-        <td colspan="2">page {{ page }} ({{ num_urls }} URLs total)</td>
-      </tr>
-      <tr>
-        {%- if has_prev -%}
-          <td><a {{ page_href(page-1) }}>previous</a></td>
-        {%- else -%}
-          <td></td>
-        {%- endif -%}
-        {%- if has_next -%}
-          <td><a {{ page_href(page+1) }}>next</a></td>
-        {%- else -%}
-          <td></td>
-        {%- endif -%}
-      </tr>
-    </table>
+    <div class="pager">
+      {{ render_pagination_widget(pagination, '.overview') }}
+    </div>
   </div>
 </div>
 </body>

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -20,7 +20,12 @@
     {% for page in pagination.iter_pages() %}
       {% if page %}
         {% if page != pagination.page %}
-          <a href="{{ url_for(endpoint, page=page, per_page=pagination.per_page) }}">{{ page }}</a>
+          <a href="{{
+              url_for(endpoint, page=page, per_page=pagination.per_page, sort=sort_by, filter=url_filter)
+              }}"
+          >
+            {{ page }}
+          </a>
         {% else %}
           <strong>{{ page }}</strong>
         {% endif %}

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -12,6 +12,7 @@
     {{ pagination.first }} - {{ pagination.last }} of {{ pagination.total }}
   </div>
   <div class="pagination">
+    Page:
     {% for page in pagination.iter_pages() %}
       {% if page %}
         {% if page != pagination.page %}

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -12,6 +12,25 @@
                  page='{}'.format(page)) }}"
 {%- endmacro -%}
 
+{% macro render_pagination_widget(pagination, endpoint) %}
+  <div class="page-items">
+    {{ pagination.first }} - {{ pagination.last }} of {{ pagination.total }}
+  </div>
+  <div class="pagination">
+    {% for page in pagination.iter_pages() %}
+      {% if page %}
+        {% if page != pagination.page %}
+          <a href="{{ url_for(endpoint, page=page) }}">{{ page }}</a>
+        {% else %}
+          <strong>{{ page }}</strong>
+        {% endif %}
+      {% else %}
+        <span class="ellipsis">…</span>
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endmacro %}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/datalad_registry/tests/test_overview.py
+++ b/datalad_registry/tests/test_overview.py
@@ -1,6 +1,5 @@
 import re
 import time
-from unittest.mock import patch
 
 import pytest
 
@@ -8,26 +7,32 @@ from datalad_registry.tests.utils import create_and_register_repos, register_dat
 
 
 def test_overview_pager(client, tmp_path):
-    create_and_register_repos(client, tmp_path, 5)
+    create_and_register_repos(client, tmp_path, 26)
 
-    r_overview = client.get("/overview/")
-    assert b"previous" not in r_overview.data
-    assert b"next" not in r_overview.data
+    resp = client.get("/overview/")
+    assert "1 - 20 of 26" in resp.text
+    assert "<strong>1</strong>" in resp.text
+    assert '<a href="/overview/?page=2&amp;per_page=20">2</a>' in resp.text
+    assert "…" not in resp.text
 
-    with patch("datalad_registry.overview._PAGE_NITEMS", 2):
-        r_overview_pg1 = client.get("/overview/")
-        assert b"previous" not in r_overview_pg1.data
-        assert b"next" in r_overview_pg1.data
+    resp = client.get("/overview/?page=2&per_page=2")
+    assert "3 - 4 of 26" in resp.text
+    assert "<strong>2</strong>" in resp.text
+    assert '<a href="/overview/?page=3&amp;per_page=2">3</a>' in resp.text
+    assert resp.text.count("…") == 1
 
-        assert r_overview_pg1.data == client.get("/overview/?page=1").data
+    resp = client.get("/overview/?page=6&per_page=2")
+    assert "11 - 12 of 26" in resp.text
+    assert "<strong>6</strong>" in resp.text
+    assert '<a href="/overview/?page=5&amp;per_page=2">5</a>' in resp.text
+    assert resp.text.count("…") == 2
 
-        r_overview_pg2 = client.get("/overview/?page=2")
-        assert b"previous" in r_overview_pg2.data
-        assert b"next" in r_overview_pg2.data
+    # Invalid page numbers
+    resp = client.get("/overview/?page=3")
+    assert resp.status_code == 404
 
-        r_overview_pg3 = client.get("/overview/?page=3")
-        assert b"previous" in r_overview_pg3.data
-        assert b"next" not in r_overview_pg3.data
+    resp = client.get("/overview/?page=0")
+    assert resp.status_code == 404
 
 
 @pytest.mark.slow

--- a/datalad_registry/tests/test_overview.py
+++ b/datalad_registry/tests/test_overview.py
@@ -12,19 +12,28 @@ def test_overview_pager(client, tmp_path):
     resp = client.get("/overview/")
     assert "1 - 20 of 26" in resp.text
     assert "<strong>1</strong>" in resp.text
-    assert '<a href="/overview/?page=2&amp;per_page=20">2</a>' in resp.text
+    assert (
+        '<a href="/overview/?page=2&amp;per_page=20&amp;sort=update-desc">2</a>'
+        in resp.text
+    )
     assert "…" not in resp.text
 
     resp = client.get("/overview/?page=2&per_page=2")
     assert "3 - 4 of 26" in resp.text
     assert "<strong>2</strong>" in resp.text
-    assert '<a href="/overview/?page=3&amp;per_page=2">3</a>' in resp.text
+    assert (
+        '<a href="/overview/?page=3&amp;per_page=2&amp;sort=update-desc">3</a>'
+        in resp.text
+    )
     assert resp.text.count("…") == 1
 
     resp = client.get("/overview/?page=6&per_page=2")
     assert "11 - 12 of 26" in resp.text
     assert "<strong>6</strong>" in resp.text
-    assert '<a href="/overview/?page=5&amp;per_page=2">5</a>' in resp.text
+    assert (
+        '<a href="/overview/?page=5&amp;per_page=2&amp;sort=update-desc">5</a>'
+        in resp.text
+    )
     assert resp.text.count("…") == 2
 
     # Invalid page numbers


### PR DESCRIPTION
This PR brings a reimplementation of the pagination mechanism in the web UI. It resolves #143 and provides a more direct implementation the pagination mechanism by removing quite a few unnecessary variables.

P.S. Changes in this PR has been applied to the running instance of Datalad-registry on Typhon.