### PR TITLE
REST API endpoints for dataset URls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   DATALAD_REGISTRY_PASSWORD: foobar123
+  CELERY_BROKER_URL: "amqp://user:foobar123@127.0.0.1:5672"
 
 jobs:
   test:

--- a/datalad_registry/blueprints/api/__init__.py
+++ b/datalad_registry/blueprints/api/__init__.py
@@ -25,5 +25,7 @@ bp = APIBlueprint(
 # Ignoring flake8 rules in the following import.
 # F401: imported but unused
 # E402: module level import not at top of file
+# Attach dataset URL related API endpoints
 # Attach URL metadata related API endpoints
+from . import dataset_urls  # noqa: F401, E402
 from . import url_metadata  # noqa: F401, E402

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -37,9 +37,7 @@ class _QueryParams(BaseModel):
 
     url: Optional[Union[FileUrl, AnyUrl, Path]] = Field(None, description="The URL")
 
-    dataset_id: Optional[UUID] = Field(
-        None, description="The ID, a UUID, of the dataset"
-    )
+    ds_id: Optional[UUID] = Field(None, description="The ID, a UUID, of the dataset")
 
     min_annex_key_count: Optional[int] = Field(
         None, description="The minimum number of annex keys "
@@ -175,7 +173,7 @@ def dataset_urls(query: _QueryParams):
 
     append_constrain_arg_lst = [
         (query.url, URL.url, operator.eq, str),
-        (query.dataset_id, URL.ds_id, operator.eq, str),
+        (query.ds_id, URL.ds_id, operator.eq, str),
         (query.min_annex_key_count, URL.annex_key_count, operator.ge),
         (query.max_annex_key_count, URL.annex_key_count, operator.le),
         (

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -75,6 +75,9 @@ class DatasetURLs(BaseModel):
 
     __root__: list[DatasetURLRespModel]
 
+    class Config:
+        orm_mode = True
+
 
 @bp.post(f"{_URL_PREFIX}")
 def create_dataset_url():

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -34,13 +34,12 @@ class DatasetURLSubmitModel(BaseModel):
     url: Union[FileUrl, AnyUrl, Path] = Field(..., description="The URL")
 
 
-class DatasetURLRespModel(BaseModel):
+class DatasetURLRespModel(DatasetURLSubmitModel):
     """
     Model for representing the database model URL in response communication
     """
 
     id: int = Field(..., alias="id", description="The ID of the dataset URL")
-    url: Union[FileUrl, AnyUrl, Path] = Field(..., description="The URL")
     dataset_id: Optional[UUID] = Field(
         ..., alias="ds_id", description="The ID, a UUID, of the dataset"
     )

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 from flask import abort
 from flask_openapi3 import Tag
-from pydantic import AnyUrl, BaseModel, Field, FileUrl
+from pydantic import AnyUrl, BaseModel, Field, FileUrl, validator
 from sqlalchemy import and_
 from sqlalchemy.sql.elements import BinaryExpression
 
@@ -92,6 +92,17 @@ class DatasetURLSubmitModel(BaseModel):
     """
 
     url: Union[FileUrl, AnyUrl, Path] = Field(..., description="The URL")
+
+    # flake8 detect errors incorrectly in the following method
+    # by using @validator path_url_must_be_absolute is actually a class method
+    # The following errors are ignored:
+    # B902 Invalid first argument 'cls' used for instance method.
+    # U100 Unused argument 'cls'
+    @validator("url")
+    def path_url_must_be_absolute(cls, v):  # noqa: B902, U100
+        if isinstance(v, Path) and not v.is_absolute():
+            raise ValueError("Path URLs must be absolute")
+        return v
 
 
 class DatasetURLRespModel(DatasetURLSubmitModel):

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -26,6 +26,14 @@ class _PathParams(BaseModel):
     id: int = Field(..., description="The ID of the dataset URL")
 
 
+class DatasetURLSubmitModel(BaseModel):
+    """
+    Model for representing the database model URL for submission communication
+    """
+
+    url: Union[FileUrl, AnyUrl, Path] = Field(..., description="The URL")
+
+
 class DatasetURLRespModel(BaseModel):
     """
     Model for representing the database model URL in response communication

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -22,6 +22,15 @@ _URL_PREFIX = "/dataset-urls"
 _TAG = Tag(name="Dataset URLs", description="API endpoints for dataset URLs")
 
 
+def path_url_must_be_absolute(url):
+    """
+    Validator for the path URL field that ensures that the URL is absolute
+    """
+    if isinstance(url, Path) and not url.is_absolute():
+        raise ValueError("Path URLs must be absolute")
+    return url
+
+
 class _PathParams(BaseModel):
     """
     Pydantic model for representing the path parameters for API endpoints related to
@@ -86,6 +95,11 @@ class _QueryParams(BaseModel):
         "on the dataset URL",
     )
 
+    # Validator
+    _path_url_must_be_absolute = validator("url", allow_reuse=True)(
+        path_url_must_be_absolute
+    )
+
 
 class DatasetURLSubmitModel(BaseModel):
     """
@@ -94,16 +108,10 @@ class DatasetURLSubmitModel(BaseModel):
 
     url: Union[FileUrl, AnyUrl, Path] = Field(..., description="The URL")
 
-    # flake8 detect errors incorrectly in the following method
-    # by using @validator path_url_must_be_absolute is actually a class method
-    # The following errors are ignored:
-    # B902 Invalid first argument 'cls' used for instance method.
-    # U100 Unused argument 'cls'
-    @validator("url")
-    def path_url_must_be_absolute(cls, v):  # noqa: B902, U100
-        if isinstance(v, Path) and not v.is_absolute():
-            raise ValueError("Path URLs must be absolute")
-        return v
+    # Validator
+    _path_url_must_be_absolute = validator("url", allow_reuse=True)(
+        path_url_must_be_absolute
+    )
 
 
 class DatasetURLRespModel(DatasetURLSubmitModel):

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -26,6 +26,58 @@ class _PathParams(BaseModel):
     id: int = Field(..., description="The ID of the dataset URL")
 
 
+class _QueryParams(BaseModel):
+    """
+    Pydantic model for representing the query parameters to query
+    the dataset_urls endpoint
+    """
+
+    url: Optional[Union[FileUrl, AnyUrl, Path]] = Field(None, description="The URL")
+
+    dataset_id: Optional[UUID] = Field(
+        None, description="The ID, a UUID, of the dataset"
+    )
+
+    min_annex_key_count: Optional[int] = Field(
+        None, description="The minimum number of annex keys "
+    )
+    max_annex_key_count: Optional[int] = Field(
+        None, description="The maximum number of annex keys "
+    )
+
+    min_annexed_files_in_wt_count: Optional[int] = Field(
+        None, description="The minimum number of annexed files in the working tree"
+    )
+    max_annexed_files_in_wt_count: Optional[int] = Field(
+        None, description="The maximum number of annexed files in the working tree"
+    )
+
+    min_annexed_files_in_wt_size: Optional[int] = Field(
+        None,
+        description="The minimum size of annexed files in the working tree in bytes",
+    )
+    max_annexed_files_in_wt_size: Optional[int] = Field(
+        None,
+        description="The maximum size of annexed files in the working tree in bytes",
+    )
+
+    earliest_last_update: Optional[datetime] = Field(
+        None,
+        description="The earliest last update time",
+    )
+    latest_last_update: Optional[datetime] = Field(
+        None,
+        description="The latest last update time",
+    )
+
+    min_git_objects_kb: Optional[int] = Field(
+        None, description="The minimum size of the `.git/objects` in KiB"
+    )
+    max_git_objects_kb: Optional[int] = Field(
+        None, description="The maximum size of the `.git/objects` in KiB"
+    )
+
+
 class DatasetURLSubmitModel(BaseModel):
     """
     Model for representing the database model URL for submission communication
@@ -92,7 +144,7 @@ def create_dataset_url():
     responses={"200": DatasetURLs},
     tags=[_TAG],
 )
-def dataset_urls():
+def dataset_urls(query: _QueryParams):
     """
     Get all dataset URLs that satisfy the constraints imposed by the query parameters.
     """

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -258,7 +258,9 @@ def dataset_urls(query: _QueryParams):
     # ==== Gathering constraints from query parameters ends ====
 
     ds_urls = DatasetURLs.from_orm(
-        db.session.execute(db.select(URL).filter(and_(*constraints))).scalars().all()
+        db.session.execute(db.select(URL).filter(and_(True, *constraints)))
+        .scalars()
+        .all()
     )
     return json_resp_from_str(ds_urls.json())
 

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -76,7 +76,23 @@ def create_dataset_url():
     raise NotImplementedError
 
 
-@bp.get(f"{_URL_PREFIX}")
+@bp.get(
+    f"{_URL_PREFIX}",
+    extra_responses={
+        "200": {
+            "description": "A filtered list of dataset URls",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/DatasetURLRespModel"},
+                    }
+                }
+            },
+        },
+    },
+    tags=[_TAG],
+)
 def dataset_urls():
     """
     Get all dataset URLs that satisfy the constraints imposed by the query parameters.

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -93,7 +93,7 @@ class DatasetURLRespModel(DatasetURLSubmitModel):
     """
 
     id: int = Field(..., alias="id", description="The ID of the dataset URL")
-    dataset_id: Optional[UUID] = Field(
+    ds_id: Optional[UUID] = Field(
         ..., alias="ds_id", description="The ID, a UUID, of the dataset"
     )
     describe: Optional[str] = Field(

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -1,0 +1,29 @@
+# This file is for defining the API endpoints related to dataset URls
+
+from . import bp
+
+_URL_PREFIX = "/dataset-urls"
+
+
+@bp.post(f"{_URL_PREFIX}")
+def create_dataset_url():
+    """
+    Create a new dataset URL.
+    """
+    raise NotImplementedError
+
+
+@bp.get(f"{_URL_PREFIX}")
+def dataset_urls():
+    """
+    Get all dataset URLs that satisfy the constraints imposed by the query parameters.
+    """
+    raise NotImplementedError
+
+
+@bp.get(f"{_URL_PREFIX}/<int:dataset_url_id>")
+def dataset_url(dataset_url_id):
+    """
+    Get a dataset URL by ID.
+    """
+    raise NotImplementedError

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -68,6 +68,14 @@ class DatasetURLRespModel(DatasetURLSubmitModel):
         orm_mode = True
 
 
+class DatasetURLs(BaseModel):
+    """
+    Model for representing a list of dataset URLs in response communication
+    """
+
+    __root__: list[DatasetURLRespModel]
+
+
 @bp.post(f"{_URL_PREFIX}")
 def create_dataset_url():
     """
@@ -78,19 +86,7 @@ def create_dataset_url():
 
 @bp.get(
     f"{_URL_PREFIX}",
-    extra_responses={
-        "200": {
-            "description": "A filtered list of dataset URls",
-            "content": {
-                "application/json": {
-                    "schema": {
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/DatasetURLRespModel"},
-                    }
-                }
-            },
-        },
-    },
+    responses={"200": DatasetURLs},
     tags=[_TAG],
 )
 def dataset_urls():

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -48,7 +48,7 @@ class DatasetURLRespModel(DatasetURLSubmitModel):
         alias="head_describe",
         description="The output of `git describe --tags --always` on the dataset",
     )
-    annex_key_count: Optional[int] = Field(..., description="The number of annex keys ")
+    annex_key_count: Optional[int] = Field(..., description="The number of annex keys")
     annexed_files_in_wt_count: Optional[int] = Field(
         ..., description="The number of annexed files in the working tree"
     )

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -21,7 +21,7 @@ class _PathParams(BaseModel):
     dataset URLs.
     """
 
-    dataset_url_id: int = Field(..., description="The ID of the dataset URL")
+    id: int = Field(..., description="The ID of the dataset URL")
 
 
 class DatasetURLModel(BaseModel):
@@ -78,7 +78,7 @@ def dataset_urls():
 
 
 @bp.get(
-    f"{_URL_PREFIX}/<int:dataset_url_id>",
+    f"{_URL_PREFIX}/<int:id>",
     responses={"200": DatasetURLModel},
     tags=[_TAG],
 )
@@ -86,5 +86,5 @@ def dataset_url(path: _PathParams):
     """
     Get a dataset URL by ID.
     """
-    data = DatasetURLModel.from_orm(db.get_or_404(URL, path.dataset_url_id))
+    data = DatasetURLModel.from_orm(db.get_or_404(URL, path.id))
     return data.dict()

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -161,15 +161,15 @@ def dataset_urls(query: _QueryParams):
     """
 
     def append_constraint(
-        qry, db_model_column, op, qry_spec_transform=(lambda x: x)
+        db_model_column, op, qry, qry_spec_transform=(lambda x: x)
     ) -> None:
         """
         Append a filter constraint corresponding to a given query parameter value
         to the list of filter constraints.
 
-        :param qry: The query parameter value
         :param db_model_column: The SQLAlchemy model column to build the constraint with
         :param op: The operator to build the constraint with
+        :param qry: The query parameter value
         :param qry_spec_transform: The transformation to apply to the query parameter
                                    value in to build the constraint. Defaults to the
                                    identity function.
@@ -182,27 +182,27 @@ def dataset_urls(query: _QueryParams):
     constraints: list[BinaryExpression] = []
 
     append_constrain_arg_lst = [
-        (query.url, URL.url, operator.eq, str),
-        (query.ds_id, URL.ds_id, operator.eq, str),
-        (query.min_annex_key_count, URL.annex_key_count, operator.ge),
-        (query.max_annex_key_count, URL.annex_key_count, operator.le),
+        (URL.url, operator.eq, query.url, str),
+        (URL.ds_id, operator.eq, query.ds_id, str),
+        (URL.annex_key_count, operator.ge, query.min_annex_key_count),
+        (URL.annex_key_count, operator.le, query.max_annex_key_count),
         (
-            query.min_annexed_files_in_wt_count,
             URL.annexed_files_in_wt_count,
             operator.ge,
+            query.min_annexed_files_in_wt_count,
         ),
         (
-            query.max_annexed_files_in_wt_count,
             URL.annexed_files_in_wt_count,
             operator.le,
+            query.max_annexed_files_in_wt_count,
         ),
-        (query.min_annexed_files_in_wt_size, URL.annexed_files_in_wt_size, operator.ge),
-        (query.max_annexed_files_in_wt_size, URL.annexed_files_in_wt_size, operator.le),
-        (query.earliest_last_update, URL.info_ts, operator.ge),
-        (query.latest_last_update, URL.info_ts, operator.le),
-        (query.min_git_objects_kb, URL.git_objects_kb, operator.ge),
-        (query.max_git_objects_kb, URL.git_objects_kb, operator.le),
-        (query.processed, URL.processed, operator.eq),
+        (URL.annexed_files_in_wt_size, operator.ge, query.min_annexed_files_in_wt_size),
+        (URL.annexed_files_in_wt_size, operator.le, query.max_annexed_files_in_wt_size),
+        (URL.info_ts, operator.ge, query.earliest_last_update),
+        (URL.info_ts, operator.le, query.latest_last_update),
+        (URL.git_objects_kb, operator.ge, query.min_git_objects_kb),
+        (URL.git_objects_kb, operator.le, query.max_git_objects_kb),
+        (URL.processed, operator.eq, query.processed),
     ]
 
     for args in append_constrain_arg_lst:

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -78,6 +78,12 @@ class _QueryParams(BaseModel):
         None, description="The maximum size of the `.git/objects` in KiB"
     )
 
+    processed: Optional[bool] = Field(
+        None,
+        description="Whether an initial processing has been completed "
+        "on the dataset URL",
+    )
+
 
 class DatasetURLSubmitModel(BaseModel):
     """

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -119,7 +119,7 @@ class DatasetURLRespModel(DatasetURLSubmitModel):
     Model for representing the database model URL in response communication
     """
 
-    id: int = Field(..., alias="id", description="The ID of the dataset URL")
+    id: int = Field(..., description="The ID of the dataset URL")
     ds_id: Optional[UUID] = Field(
         ..., alias="ds_id", description="The ID, a UUID, of the dataset"
     )

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -26,9 +26,9 @@ class _PathParams(BaseModel):
     id: int = Field(..., description="The ID of the dataset URL")
 
 
-class DatasetURLModel(BaseModel):
+class DatasetURLRespModel(BaseModel):
     """
-    Model for representing the database model URL for communication
+    Model for representing the database model URL in response communication
     """
 
     id: int = Field(..., alias="id", description="The ID of the dataset URL")
@@ -79,12 +79,12 @@ def dataset_urls():
 
 @bp.get(
     f"{_URL_PREFIX}/<int:id>",
-    responses={"200": DatasetURLModel},
+    responses={"200": DatasetURLRespModel},
     tags=[_TAG],
 )
 def dataset_url(path: _PathParams):
     """
     Get a dataset URL by ID.
     """
-    ds_url = DatasetURLModel.from_orm(db.get_or_404(URL, path.id))
+    ds_url = DatasetURLRespModel.from_orm(db.get_or_404(URL, path.id))
     return json_resp_from_str(ds_url.json())

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -1,13 +1,15 @@
 # This file is for defining the API endpoints related to dataset URls
 
 from datetime import datetime
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 from uuid import UUID
 
 from flask_openapi3 import Tag
-from pydantic import BaseModel, Field
+from pydantic import AnyUrl, BaseModel, Field, FileUrl
 
 from datalad_registry.models import URL, db
+from datalad_registry.utils.flask_tools import json_resp_from_str
 
 from . import bp
 
@@ -30,7 +32,7 @@ class DatasetURLModel(BaseModel):
     """
 
     id: int = Field(..., alias="id", description="The ID of the dataset URL")
-    url: str = Field(..., description="The URL")
+    url: Union[FileUrl, AnyUrl, Path] = Field(..., description="The URL")
     dataset_id: Optional[UUID] = Field(
         ..., alias="ds_id", description="The ID, a UUID, of the dataset"
     )
@@ -84,5 +86,5 @@ def dataset_url(path: _PathParams):
     """
     Get a dataset URL by ID.
     """
-    data = DatasetURLModel.from_orm(db.get_or_404(URL, path.id))
-    return data.dict()
+    ds_url = DatasetURLModel.from_orm(db.get_or_404(URL, path.id))
+    return json_resp_from_str(ds_url.json())

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -116,6 +116,10 @@ class DatasetURLRespModel(DatasetURLSubmitModel):
     git_objects_kb: Optional[int] = Field(
         ..., description="The size of the `.git/objects` in KiB"
     )
+    processed: bool = Field(
+        description="Whether an initial processing has been completed "
+        "on the dataset URL"
+    )
 
     class Config:
         orm_mode = True

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -202,6 +202,7 @@ def dataset_urls(query: _QueryParams):
         (query.latest_last_update, URL.info_ts, operator.le),
         (query.min_git_objects_kb, URL.git_objects_kb, operator.ge),
         (query.max_git_objects_kb, URL.git_objects_kb, operator.le),
+        (query.processed, URL.processed, operator.eq),
     ]
 
     for args in append_constrain_arg_lst:

--- a/datalad_registry/blueprints/api/dataset_urls.py
+++ b/datalad_registry/blueprints/api/dataset_urls.py
@@ -29,9 +29,7 @@ class DatasetURLModel(BaseModel):
     Model for representing the database model URL for communication
     """
 
-    dataset_url_id: int = Field(
-        ..., alias="id", description="The ID of the dataset URL"
-    )
+    id: int = Field(..., alias="id", description="The ID of the dataset URL")
     url: str = Field(..., description="The URL")
     dataset_id: Optional[UUID] = Field(
         ..., alias="ds_id", description="The ID, a UUID, of the dataset"

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -9,7 +9,7 @@ from celery import group
 from datalad import api as dl
 from datalad.distribution.dataset import require_dataset
 from datalad.support.exceptions import IncompleteResultsError
-from pydantic import StrictStr, parse_obj_as, validate_arguments
+from pydantic import StrictInt, StrictStr, parse_obj_as, validate_arguments
 
 from datalad_registry import celery
 from datalad_registry.models import URL, URLMetadata, db
@@ -428,3 +428,23 @@ def extract_meta(url_id: int, dataset_path: str, extractor: str) -> ExtractMetaS
         raise RuntimeError(
             f"Extractor {extractor} did not produce any valid metadata for {url.url}"
         )
+
+
+@celery.task
+@validate_arguments
+def process_dataset_url(dataset_url_id: StrictInt) -> None:
+    """
+    Process a dataset URL
+
+    :param dataset_url_id: The ID (primary key) of the dataset URL in the database
+
+    note:: If the dataset URL specified by dataset_url_id does not exist
+           in the database or if the dataset URL has already been processed,
+           this function will raise a ValueError. Otherwise, the corresponding dataset
+           of the URL will be cloned to the local cache, the null cells of
+           the dataset URL in the database will be populated,
+           the `processed` cell of the dataset URL in the database will be set
+           to `True`, and the metadata extractions of the dataset as celery tasks
+           will be initiated.
+    """
+    raise NotImplementedError("This function is not implemented yet")

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -87,6 +87,28 @@ class TestDatasetURLs:
         resp = flask_client.get("/api/v2/dataset-urls", query_string=query_params)
         assert resp.status_code == 422
 
+    @pytest.mark.parametrize(
+        "query_params",
+        [
+            {"url": "https://www.example.com"},
+            {"ds_id": "2a0b7b7b-a984-4c4a-844c-be3132291d7b"},
+            {"min_annex_key_count": "1"},
+            {"max_annex_key_count": 2},
+            {"min_annexed_files_in_wt_count": 200},
+            {"max_annexed_files_in_wt_count": "40"},
+            {"min_annexed_files_in_wt_size": 33},
+            {"max_annexed_files_in_wt_size": 21},
+            {"earliest_last_update": 656409661000},
+            {"latest_last_update": "2001-03-22T01:22:34"},
+            {"min_git_objects_kb": 40},
+            {"max_git_objects_kb": "100"},
+            {"processed": True},
+        ],
+    )
+    def test_valid_query_params(self, flask_client, query_params):
+        resp = flask_client.get("/api/v2/dataset-urls", query_string=query_params)
+        assert resp.status_code == 200
+
 
 @pytest.mark.usefixtures("populate_with_2_dataset_urls")
 class TestDatasetURL:

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -1,0 +1,52 @@
+import pytest
+
+from datalad_registry.blueprints.api.dataset_urls import DatasetURLRespModel
+
+
+class TestCreateDatasetURL:
+    def test_without_body(self, flask_client):
+        resp = flask_client.post("/api/v2/dataset-urls")
+        assert resp.status_code == 422
+
+    @pytest.mark.parametrize(
+        "request_json_body",
+        [
+            {},
+            {"url": ""},
+            {"url": "hehe"},
+            {"url": "haha/hehe"},
+            {"url": "www.example.com"},
+        ],
+    )
+    def test_invalid_body(self, flask_client, request_json_body):
+        resp = flask_client.post("/api/v2/dataset-urls", json=request_json_body)
+        assert resp.status_code == 422
+
+    @pytest.mark.parametrize(
+        "request_json_body",
+        [{"url": "https://example.com"}, {"url": "/hehe"}, {"url": "/haha/hehe"}],
+    )
+    def test_valid_body(self, flask_client, request_json_body):
+        resp = flask_client.post("/api/v2/dataset-urls", json=request_json_body)
+        assert resp.status_code == 201
+
+        resp_json_body = resp.json
+
+        # Ensure the keys of the JSON body of the response are the field names of
+        # DatasetURLRespModel
+        model_field_names = set(
+            DatasetURLRespModel.schema(by_alias=False)["properties"]
+        )
+        resp_json_body_keys = set(resp_json_body)
+        assert resp_json_body_keys == model_field_names
+
+        # Ensure the `processed` field is the default value of False
+        assert not resp_json_body["processed"]
+
+
+class TestDatasetURLs:
+    pass
+
+
+class TestDatasetURL:
+    pass

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -13,7 +13,7 @@ def populate_with_2_dataset_urls(flask_app):
     from datalad_registry.models import URL, db
 
     dataset_url1 = URL(url="https://example.com")
-    dataset_url2 = URL(url="https://www.google.com")
+    dataset_url2 = URL(url="https://docs.datalad.org")
     dataset_url3 = URL(url="/foo/bar")
 
     with flask_app.app_context():
@@ -45,7 +45,7 @@ def populate_with_dataset_urls(flask_app):
             processed=True,
         ),
         URL(
-            url="http://www.yahoo.com",
+            url="http://www.datalad.org",
             ds_id="2a0b7b7b-a984-4c4a-844c-be3132291d7c",
             head_describe="1234",
             annex_key_count=40,
@@ -56,7 +56,7 @@ def populate_with_dataset_urls(flask_app):
             processed=True,
         ),
         URL(
-            url="https://www.youtube.com",
+            url="https://handbook.datalad.org",
             ds_id="2a0b7b7b-a984-4c4a-844c-be3132291a7c",
             head_describe="1234",
             annex_key_count=90,
@@ -67,7 +67,7 @@ def populate_with_dataset_urls(flask_app):
             processed=True,
         ),
         URL(
-            url="https://www.facebook.com",
+            url="https://www.dandiarchive.org",
             processed=False,
         ),
     ]
@@ -183,50 +183,50 @@ class TestDatasetURLs:
                 {},
                 {
                     "https://www.example.com",
-                    "http://www.yahoo.com",
-                    "https://www.youtube.com",
-                    "https://www.facebook.com",
+                    "http://www.datalad.org",
+                    "https://handbook.datalad.org",
+                    "https://www.dandiarchive.org",
                 },
             ),
             ({"url": "https://www.example.com"}, {"https://www.example.com"}),
             (
                 {"ds_id": "2a0b7b7b-a984-4c4a-844c-be3132291d7c"},
-                {"http://www.yahoo.com"},
+                {"http://www.datalad.org"},
             ),
             (
                 {"min_annex_key_count": "39"},
-                {"http://www.yahoo.com", "https://www.youtube.com"},
+                {"http://www.datalad.org", "https://handbook.datalad.org"},
             ),
             (
                 {"min_annex_key_count": "39", "max_annex_key_count": 40},
-                {"http://www.yahoo.com"},
+                {"http://www.datalad.org"},
             ),
             (
                 {
                     "min_annexed_files_in_wt_count": 190,
                     "max_annexed_files_in_wt_count": 500,
                 },
-                {"https://www.example.com", "https://www.youtube.com"},
+                {"https://www.example.com", "https://handbook.datalad.org"},
             ),
             ({"min_annexed_files_in_wt_size": 1000_001}, set()),
-            ({"max_annexed_files_in_wt_size": 500}, {"http://www.yahoo.com"}),
+            ({"max_annexed_files_in_wt_size": 500}, {"http://www.datalad.org"}),
             (
                 {"max_annexed_files_in_wt_size": 2000},
-                {"https://www.example.com", "http://www.yahoo.com"},
+                {"https://www.example.com", "http://www.datalad.org"},
             ),
             (
                 {
                     "min_annexed_files_in_wt_size": 300,
                     "max_annexed_files_in_wt_size": 2200,
                 },
-                {"https://www.example.com", "http://www.yahoo.com"},
+                {"https://www.example.com", "http://www.datalad.org"},
             ),
             (
                 {"earliest_last_update": "2001-03-22T01:22:34"},
                 {
                     "https://www.example.com",
-                    "http://www.yahoo.com",
-                    "https://www.youtube.com",
+                    "http://www.datalad.org",
+                    "https://handbook.datalad.org",
                 },
             ),
             (
@@ -238,20 +238,20 @@ class TestDatasetURLs:
             ),
             (
                 {"min_git_objects_kb": 1000, "max_git_objects_kb": 2000},
-                {"http://www.yahoo.com"},
+                {"http://www.datalad.org"},
             ),
             (
                 {"processed": True},
                 {
                     "https://www.example.com",
-                    "http://www.yahoo.com",
-                    "https://www.youtube.com",
+                    "http://www.datalad.org",
+                    "https://handbook.datalad.org",
                 },
             ),
-            ({"processed": False}, {"https://www.facebook.com"}),
+            ({"processed": False}, {"https://www.dandiarchive.org"}),
             (
                 {"min_annex_key_count": "39", "max_annexed_files_in_wt_size": 2200},
-                {"http://www.yahoo.com"},
+                {"http://www.datalad.org"},
             ),
         ],
     )

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -3,6 +3,26 @@ import pytest
 from datalad_registry.blueprints.api.dataset_urls import DatasetURLRespModel
 
 
+@pytest.fixture
+def populate_with_2_dataset_urls(flask_app):
+    """
+    Populate the url table with 2 URLs, at position 1 and 3.
+    """
+    from datalad_registry.models import URL, db
+
+    dataset_url1 = URL(url="https://example.com")
+    dataset_url2 = URL(url="https://www.google.com")
+    dataset_url3 = URL(url="/foo/bar")
+
+    with flask_app.app_context():
+        for url in [dataset_url1, dataset_url2, dataset_url3]:
+            db.session.add(url)
+        db.session.commit()
+
+        db.session.delete(dataset_url2)
+        db.session.commit()
+
+
 class TestCreateDatasetURL:
     def test_without_body(self, flask_client):
         resp = flask_client.post("/api/v2/dataset-urls")
@@ -48,5 +68,29 @@ class TestDatasetURLs:
     pass
 
 
+@pytest.mark.usefixtures("populate_with_2_dataset_urls")
 class TestDatasetURL:
-    pass
+    @pytest.mark.parametrize("dataset_url_id", [-100, -1, 0, 2, 60, 71, 100])
+    def test_invalid_id(self, flask_client, dataset_url_id):
+        resp = flask_client.get(f"/api/v2/dataset-urls/{dataset_url_id}")
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize(
+        "dataset_url_id, url", [(1, "https://example.com"), (3, "/foo/bar")]
+    )
+    def test_valid_id(self, flask_client, dataset_url_id, url):
+        resp = flask_client.get(f"/api/v2/dataset-urls/{dataset_url_id}")
+        assert resp.status_code == 200
+
+        resp_json_body = resp.json
+
+        # Ensure the keys of the JSON body of the response are the field names of
+        # DatasetURLRespModel
+        model_field_names = set(
+            DatasetURLRespModel.schema(by_alias=False)["properties"]
+        )
+        resp_json_body_keys = set(resp_json_body)
+        assert resp_json_body_keys == model_field_names
+
+        # Ensure the correct URL is fetched
+        assert resp_json_body["url"] == url

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -65,7 +65,27 @@ class TestCreateDatasetURL:
 
 
 class TestDatasetURLs:
-    pass
+    @pytest.mark.parametrize(
+        "query_params",
+        [
+            {"url": "www.example.com"},
+            {"ds_id": "34"},
+            {"min_annex_key_count": "ab"},
+            {"max_annex_key_count": "bc"},
+            {"min_annexed_files_in_wt_count": "cd"},
+            {"max_annexed_files_in_wt_count": "def"},
+            {"min_annexed_files_in_wt_size": "efg"},
+            {"max_annexed_files_in_wt_size": "hij"},
+            {"earliest_last_update": "jkl"},
+            {"latest_last_update": "klm"},
+            {"min_git_objects_kb": "lmn"},
+            {"max_git_objects_kb": "mno"},
+            {"processed": "nop"},
+        ],
+    )
+    def test_invalid_query_params(self, flask_client, query_params):
+        resp = flask_client.get("/api/v2/dataset-urls", query_string=query_params)
+        assert resp.status_code == 422
 
 
 @pytest.mark.usefixtures("populate_with_2_dataset_urls")

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -118,6 +118,17 @@ class TestCreateDatasetURL:
         # Ensure the `processed` field is the default value of False
         assert not resp_json_body["processed"]
 
+    @pytest.mark.usefixtures("populate_with_2_dataset_urls")
+    @pytest.mark.parametrize(
+        "request_json_body", [{"url": "https://example.com"}, {"url": "/foo/bar"}]
+    )
+    def test_resubmission(self, flask_client, request_json_body):
+        """
+        Test resubmitting URLs that already exist in the database
+        """
+        resp = flask_client.post("/api/v2/dataset-urls", json=request_json_body)
+        assert resp.status_code == 409
+
 
 class TestDatasetURLs:
     @pytest.mark.parametrize(

--- a/datalad_registry/utils/flask_tools.py
+++ b/datalad_registry/utils/flask_tools.py
@@ -1,0 +1,21 @@
+from http import HTTPStatus
+from typing import Optional, Union
+
+from flask import current_app
+
+
+def json_resp_from_str(
+    json_str: str, status: Optional[Union[int, str, HTTPStatus]] = None
+):
+    """
+    Return a Flask response object with the given JSON string as the response body
+
+    :param json_str: The JSON string to use as the response body
+    :param status: The HTTP response status code of the response
+    :return: The Flask response object with the given JSON string as the response body
+
+    Note: This requires an active request or application context of Flask
+    """
+    return current_app.response_class(
+        json_str, mimetype="application/json", status=status
+    )


### PR DESCRIPTION
This PR provides RESTful API endpoints for accessing dataset URLs. The up-to-date documentation of these endpoints is available in the OpenAPI standard and available for view at `/openapi` of the Datalad-registry on Typhon.

Please note that [the backend of the `POST /api/v2/dataset-urls` endpoint](https://github.com/datalad/datalad-registry/blob/5ec5915c6de4cff3016c7c037a5c465e4c1674de/datalad_registry/tasks.py#L450) is not yet implemented but will be provided in a subsequent PR.

The PR is based on #152 and should be rebased once #152 is merged.