### PR TITLE
Feature: Utilize Flask OpenAPI3 in parsing, validation in APIs and generation of OpenAPI specs

### DIFF
--- a/datalad_registry/blueprints/api/__init__.py
+++ b/datalad_registry/blueprints/api/__init__.py
@@ -1,6 +1,26 @@
 from flask_openapi3 import APIBlueprint
+from pydantic import BaseModel, Field
 
-bp = APIBlueprint("api", __name__, url_prefix="/api/v2")
+
+class HTTPExceptionResp(BaseModel):
+    """
+    Default HTTP exception response
+    """
+
+    code: int = Field(..., description="HTTP status code")
+    name: str = Field(..., description="HTTP status name")
+    description: str = Field(..., description="HTTP status description")
+
+
+bp = APIBlueprint(
+    "api",
+    __name__,
+    url_prefix="/api/v2",
+    abp_responses={
+        "404": HTTPExceptionResp,
+        "500": HTTPExceptionResp,
+    },
+)
 
 # Ignoring flake8 rules in the following import.
 # F401: imported but unused

--- a/datalad_registry/blueprints/api/__init__.py
+++ b/datalad_registry/blueprints/api/__init__.py
@@ -1,6 +1,6 @@
-from flask import Blueprint
+from flask_openapi3 import APIBlueprint
 
-bp = Blueprint("api", __name__)
+bp = APIBlueprint("api", __name__, url_prefix="/api/v2")
 
 # Ignoring flake8 rules in the following import.
 # F401: imported but unused

--- a/datalad_registry/blueprints/api/url_metadata.py
+++ b/datalad_registry/blueprints/api/url_metadata.py
@@ -23,8 +23,7 @@ class _PathParams(BaseModel):
 
 class URLMetadataModel(BaseModel):
     """
-    Pydantic model for representing the database model URLMetadata for communication
-    in JSON
+    Model for representing the database model URLMetadata for communication
     """
 
     dataset_describe: StrictStr

--- a/datalad_registry/blueprints/api/url_metadata.py
+++ b/datalad_registry/blueprints/api/url_metadata.py
@@ -1,20 +1,35 @@
 # This file is for defining the API endpoints related to dataset URL metadata,
 # i.e. the metadata of datasets at individual URLs.
 
+from flask_openapi3 import Tag
+from pydantic import BaseModel, Field
+
 from datalad_registry.com_models import URLMetadataModel
 from datalad_registry.models import URLMetadata, db
 
 from . import bp
 
 _URL_PREFIX = "/url-metadata"
+_TAG = Tag(name="URL Metadata", description="API endpoints for URL metadata")
 
 
-@bp.get(f"{_URL_PREFIX}/<int:url_metadata_id>")
-def url_metadata(url_metadata_id):
+class _PathParams(BaseModel):
+    """
+    Pydantic model for representing the path parameters for the URL metadata API
+    endpoints.
+    """
+
+    url_metadata_id: int = Field(..., description="The ID of the URL metadata")
+
+
+@bp.get(
+    f"{_URL_PREFIX}/<int:url_metadata_id>",
+    responses={"200": URLMetadataModel},
+    tags=[_TAG],
+)
+def url_metadata(path: _PathParams):
     """
     Get URL metadata by ID.
-
-    :param url_metadata_id: ID of the URL metadata to retrieve
     """
-    data = URLMetadataModel.from_orm(db.get_or_404(URLMetadata, url_metadata_id))
+    data = URLMetadataModel.from_orm(db.get_or_404(URLMetadata, path.url_metadata_id))
     return data.dict()

--- a/datalad_registry/blueprints/api/url_metadata.py
+++ b/datalad_registry/blueprints/api/url_metadata.py
@@ -2,9 +2,8 @@
 # i.e. the metadata of datasets at individual URLs.
 
 from flask_openapi3 import Tag
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StrictStr
 
-from datalad_registry.com_models import URLMetadataModel
 from datalad_registry.models import URLMetadata, db
 
 from . import bp
@@ -20,6 +19,23 @@ class _PathParams(BaseModel):
     """
 
     url_metadata_id: int = Field(..., description="The ID of the URL metadata")
+
+
+class URLMetadataModel(BaseModel):
+    """
+    Pydantic model for representing the database model URLMetadata for communication
+    in JSON
+    """
+
+    dataset_describe: StrictStr
+    dataset_version: StrictStr
+    extractor_name: StrictStr
+    extractor_version: StrictStr
+    extraction_parameter: dict
+    extracted_metadata: dict
+
+    class Config:
+        orm_mode = True
 
 
 @bp.get(

--- a/datalad_registry/com_models.py
+++ b/datalad_registry/com_models.py
@@ -20,20 +20,3 @@ class MetaExtractResult(BaseModel):
     action: Literal["meta_extract"]
     status: StrictStr
     metadata_record: MetadataRecord
-
-
-class URLMetadataModel(BaseModel):
-    """
-    Pydantic model for representing the database model URLMetadata for communication
-    in JSON
-    """
-
-    dataset_describe: StrictStr
-    dataset_version: StrictStr
-    extractor_name: StrictStr
-    extractor_version: StrictStr
-    extraction_parameter: dict
-    extracted_metadata: dict
-
-    class Config:
-        orm_mode = True

--- a/datalad_registry/factory.py
+++ b/datalad_registry/factory.py
@@ -102,7 +102,7 @@ def create_app(test_config: Optional[Dict[str, Any]] = None) -> Flask:
     from .blueprints.api import bp as api_bp
 
     # Register API blueprint
-    app.register_blueprint(api_bp, url_prefix="/api/v1")
+    app.register_api(api_bp)
 
     @app.errorhandler(HTTPException)
     def handle_exception(e):

--- a/datalad_registry/factory.py
+++ b/datalad_registry/factory.py
@@ -8,6 +8,7 @@ from celery.app.base import Celery
 from celery.schedules import crontab
 from flask import Flask, request
 from flask.logging import default_handler
+from flask_openapi3 import Info, OpenAPI
 from kombu.serialization import register
 from werkzeug.exceptions import HTTPException
 
@@ -70,8 +71,11 @@ def setup_celery(app: Flask, celery: Celery) -> Celery:
 
 
 def create_app(test_config: Optional[Dict[str, Any]] = None) -> Flask:
-    app = Flask(
-        FLASK_APP_NAME, instance_path=os.environ.get("DATALAD_REGISTRY_INSTANCE_PATH")
+    api_info = Info(title="Datalad Registry API", version="2.0")
+    app = OpenAPI(
+        FLASK_APP_NAME,
+        instance_path=os.environ.get("DATALAD_REGISTRY_INSTANCE_PATH"),
+        info=api_info,
     )
     instance_path = Path(app.instance_path)
     app.config.from_mapping(SQLALCHEMY_TRACK_MODIFICATIONS=False)

--- a/datalad_registry/tests/test_new_organization/test_api_json_error_response.py
+++ b/datalad_registry/tests/test_new_organization/test_api_json_error_response.py
@@ -13,8 +13,8 @@ class TestAPIJSONErrorResponse:
             "/api/haha/world",
             "/api/haha/world/",
             # Paths that lead to a 404 because a 404 error is raised in a view function
-            "/api/v1/url-metadata/1",
-            "/api/v1/url-metadata/20",
+            "/api/v2/url-metadata/1",
+            "/api/v2/url-metadata/20",
         ],
     )
     def test_404_json_response_in_api_path(self, flask_client, path):
@@ -33,8 +33,8 @@ class TestAPIJSONErrorResponse:
     @pytest.mark.parametrize(
         "path",
         [
-            "/api/v1/url-metadata/1",
-            "/api/v1/url-metadata/20",
+            "/api/v2/url-metadata/1",
+            "/api/v2/url-metadata/20",
         ],
     )
     def test_405_json_response_in_api_path(self, flask_client, path):
@@ -53,9 +53,9 @@ class TestAPIJSONErrorResponse:
     @pytest.mark.parametrize(
         "path",
         [
-            "/api/v1/url-metadata/1",
-            "/api/v1/url-metadata/33",
-            "/api/v1/url-metadata/42",
+            "/api/v2/url-metadata/1",
+            "/api/v2/url-metadata/33",
+            "/api/v2/url-metadata/42",
         ],
     )
     def test_500_json_response_in_api_path(

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_url_metadata.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_url_metadata.py
@@ -28,12 +28,12 @@ class TestURLMetadata:
     @pytest.mark.parametrize("url_metadata_id", [1, 2, 3, 60, 71, 100])
     def test_not_found(self, flask_client, url_metadata_id):
         with flask_client:
-            resp = flask_client.get(f"/api/v1/url-metadata/{url_metadata_id}")
+            resp = flask_client.get(f"/api/v2/url-metadata/{url_metadata_id}")
             assert resp.status_code == 404
 
     @pytest.mark.usefixtures("populate_with_metadata")
     def test_found(self, flask_client):
-        resp = flask_client.get("/api/v1/url-metadata/1")
+        resp = flask_client.get("/api/v2/url-metadata/1")
 
         assert resp.status_code == 200
 

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_url_metadata.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_url_metadata.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datalad_registry.com_models import URLMetadataModel
+from datalad_registry.blueprints.api.url_metadata import URLMetadataModel
 
 
 @pytest.fixture

--- a/datalad_registry/tests/test_new_organization/test_tasks/test_extract_meta.py
+++ b/datalad_registry/tests/test_new_organization/test_tasks/test_extract_meta.py
@@ -2,7 +2,7 @@ from datalad import api as dl
 from datalad.distribution.dataset import require_dataset
 import pytest
 
-from datalad_registry.com_models import URLMetadataModel
+from datalad_registry.blueprints.api.url_metadata import URLMetadataModel
 from datalad_registry.tasks import ExtractMetaStatus, extract_meta
 
 _TEST_REPO_URL = "https://github.com/datalad/testrepo--minimalds.git"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ celery==5.2.7
 click==8.1.3
 datalad==0.18.0
 datalad-metalad==0.4.12
-Flask==2.2.2
+flask-openapi3==2.3.2
 Flask-SQLAlchemy==3.0.2
 SQLAlchemy==1.4.46
 psycopg2==2.9.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     click
     datalad >= 0.18.0
     datalad-metalad >= 0.4
-    Flask
+    flask-openapi3 ~= 2.3
     Flask-SQLAlchemy
     importlib-metadata; python_version < "3.8"
     SQLAlchemy >= 1.4, < 2.0


### PR DESCRIPTION
This PR adds [Flask OpenAPI3](https://luolingchun.github.io/flask-openapi3/), a extension of Flask, as a dependency. Leveraging Flask OpenAPI3, all parsing and validation of incoming data from the API can be specified and handled by Pydantic. Additionally, an up-to-date OpenAPI specification of the API is aways available with interactive documentation such as Swagger.

As a proof concept, this PR has only made the endpoint related to URL metadata available in the OpenAPI specification. More API endpoints will be made available very soon in subsequent PRs.

The changes in the PR has been applied to the Datalad Registry instance on Typhon. Please visit `/openapi` for the interactive documentation of the API.