### PR TITLE
Remove `codecov` in Python environ of GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,6 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install wheel
-        pip install codecov
         pip install mypy types-requests
         pip install .[tests]
     - name: Set up dev server


### PR DESCRIPTION
codecov is [no longer available on pypi](https://docs.codecov.com/docs/deprecated-uploader-migration-guide#python-uploader). It's present in the Python environment of GitHub Actions workflow is not really needed because the uploading of coverage to codecov has been taken care of by `codecov/codecov-action@v3`.