### PR TITLE
Add Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/datalad/datalad-registry/branch/master/graph/badge.svg?token=CY783CBF77)](https://codecov.io/gh/datalad/datalad-registry)
+
 DataLad registry -- work in progress
 
   * [docs/openapi.yml](docs/openapi.yml)


### PR DESCRIPTION
Add the codecov badge to README.md.

This PR is based on #152. To get the relevant commits, it should be rebased once #152 is successfully merged.