### PR TITLE
Modify Datalad-registry client to adopt to API V2

### DIFF
--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -495,8 +495,7 @@ def extract_ds_meta(ds_url_id: StrictInt, extractor: StrictStr) -> ExtractMetaSt
     """
     Extract dataset level metadata from a dataset
 
-    :param url_id: The ID (primary key) of the URL of the dataset in the database
-    :param dataset_path: The path to the dataset in the local cache
+    :param ds_url_id: The ID (primary key) of the URL of the dataset in the database
     :param extractor: The name of the extractor to use
     :return: `ExtractMetaStatus.SUCCEEDED` if the extraction has produced
                  valid metadata. In this case, the metadata has been recorded to

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -381,6 +381,9 @@ _EXTRACTOR_REQUIRED_FILES = {
 @celery.task
 def extract_meta(url_id: int, dataset_path: str, extractor: str) -> ExtractMetaStatus:
     """
+    deprecated
+    todo: This function is to be put inline in `extract_ds_meta` once V1 API and its
+            associated code is removed.
     Extract dataset level metadata from a dataset
 
     :param url_id: The ID (primary key) of the URL of the dataset in the database

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -386,7 +386,7 @@ def log_error(request, exc, traceback) -> None:
     :param exc: The exception that has occurred
     :param traceback: The traceback of the exception
     """
-    raise NotImplementedError
+    lgr.error("%s\n%r\n%s\n", request, exc, traceback)
 
 
 @celery.task

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -14,6 +14,7 @@ from datalad.support.exceptions import IncompleteResultsError
 from datalad.utils import rmtree as rm_ds_tree
 from flask import current_app
 from pydantic import StrictInt, StrictStr, parse_obj_as, validate_arguments
+from sqlalchemy.exc import NoResultFound
 
 from datalad_registry import celery
 from datalad_registry.models import URL, URLMetadata, db
@@ -483,6 +484,45 @@ def extract_meta(url_id: int, dataset_path: str, extractor: str) -> ExtractMetaS
         raise RuntimeError(
             f"Extractor {extractor} did not produce any valid metadata for {url.url}"
         )
+
+
+@celery.task
+@validate_arguments
+def extract_ds_meta(ds_url_id: StrictInt, extractor: StrictStr) -> ExtractMetaStatus:
+    """
+    Extract dataset level metadata from a dataset
+
+    :param url_id: The ID (primary key) of the URL of the dataset in the database
+    :param dataset_path: The path to the dataset in the local cache
+    :param extractor: The name of the extractor to use
+    :return: `ExtractMetaStatus.SUCCEEDED` if the extraction has produced
+                 valid metadata. In this case, the metadata has been recorded to
+                 the database upon return.
+             `ExtractMetaStatus.ABORTED` if the extraction has been aborted due to some
+                 required files not being present in the dataset. For example,
+                 `.studyminimeta.yaml` is not present in the dataset for running
+                 the studyminimeta extractor.
+             `ExtractMetaStatus.SKIPPED` if the extraction has been skipped because the
+                 metadata to be extracted is already present in the database,
+                 as identified by the extractor name, URL, and dataset version.
+    :raise: ValueError if the dataset URL of the specified ID does not exist or has not
+                been processed yet.
+            RuntimeError if the extraction has produced no valid metadata.
+
+    """
+    try:
+        url = db.session.execute(db.select(URL).where(URL.id == ds_url_id)).scalar_one()
+    except NoResultFound:
+        raise ValueError(f"Dataset URL of ID: {ds_url_id} does not exist")
+
+    if not url.processed:
+        raise ValueError(
+            f"Dataset URL {url.url}, of ID: {url.id}, has not been processed yet"
+        )
+
+    assert url.cache_path is not None, "Encountered a processed URL with no cache path"
+
+    return extract_meta.run(ds_url_id, url.cache_path, extractor)
 
 
 @celery.task

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -379,6 +379,17 @@ _EXTRACTOR_REQUIRED_FILES = {
 
 
 @celery.task
+def log_error(request, exc, traceback) -> None:
+    """
+    An error handler for logging errors in tasks
+    :param request: The request in fulfilling which the error/exception has occurred
+    :param exc: The exception that has occurred
+    :param traceback: The traceback of the exception
+    """
+    raise NotImplementedError
+
+
+@celery.task
 def extract_meta(url_id: int, dataset_path: str, extractor: str) -> ExtractMetaStatus:
     """
     deprecated

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -535,7 +535,12 @@ def extract_ds_meta(ds_url_id: StrictInt, extractor: StrictStr) -> ExtractMetaSt
 
     assert url.cache_path is not None, "Encountered a processed URL with no cache path"
 
-    return extract_meta.run(ds_url_id, url.cache_path, extractor)
+    # Absolute path of the dataset clone in cache
+    cache_path_abs = (
+        Path(current_app.config["DATALAD_REGISTRY_DATASET_CACHE"]) / url.cache_path
+    )
+
+    return extract_meta.run(ds_url_id, cache_path_abs, extractor)
 
 
 @celery.task

--- a/datalad_registry/tests/test_new_organization/test_tasks/__init__.py
+++ b/datalad_registry/tests/test_new_organization/test_tasks/__init__.py
@@ -1,0 +1,1 @@
+TEST_MIN_REPO_URL = "https://github.com/datalad/testrepo--minimalds.git"

--- a/datalad_registry/tests/test_new_organization/test_tasks/conftest.py
+++ b/datalad_registry/tests/test_new_organization/test_tasks/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+
+from datalad_registry.models import URL, db
+
+_TEST_MIN_REPO_URL = "https://github.com/datalad/testrepo--minimalds.git"
+
+
+@pytest.fixture
+def populate_db_with_unprocessed_dataset_urls(
+    flask_app,
+    empty_ds_annex,
+    empty_ds_non_annex,
+    two_files_ds_annex,
+    two_files_ds_non_annex,
+):
+    """
+    Populate the database with unprocessed dataset URLs
+    """
+
+    with flask_app.app_context():
+        non_dataset_url = URL(url="https://www.datalad.org/")
+        db.session.add(non_dataset_url)  # id == 1
+
+        db.session.add(URL(url=_TEST_MIN_REPO_URL))  # id == 2
+        db.session.add(URL(url=empty_ds_annex.path))  # id == 3
+        db.session.add(URL(url=empty_ds_non_annex.path))  # id == 4
+        db.session.add(URL(url=two_files_ds_annex.path))  # id == 5
+        db.session.add(URL(url=two_files_ds_non_annex.path))  # id == 6
+
+        db.session.commit()
+
+        db.session.delete(non_dataset_url)
+        db.session.commit()  # 1 is no longer a valid dataset URL id

--- a/datalad_registry/tests/test_new_organization/test_tasks/conftest.py
+++ b/datalad_registry/tests/test_new_organization/test_tasks/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 from datalad_registry.models import URL, db
 
-_TEST_MIN_REPO_URL = "https://github.com/datalad/testrepo--minimalds.git"
+from . import TEST_MIN_REPO_URL
 
 
 @pytest.fixture
@@ -21,7 +21,7 @@ def populate_db_with_unprocessed_dataset_urls(
         non_dataset_url = URL(url="https://www.datalad.org/")
         db.session.add(non_dataset_url)  # id == 1
 
-        db.session.add(URL(url=_TEST_MIN_REPO_URL))  # id == 2
+        db.session.add(URL(url=TEST_MIN_REPO_URL))  # id == 2
         db.session.add(URL(url=empty_ds_annex.path))  # id == 3
         db.session.add(URL(url=empty_ds_non_annex.path))  # id == 4
         db.session.add(URL(url=two_files_ds_annex.path))  # id == 5

--- a/datalad_registry/tests/test_new_organization/test_tasks/test_extract_ds_meta.py
+++ b/datalad_registry/tests/test_new_organization/test_tasks/test_extract_ds_meta.py
@@ -1,0 +1,86 @@
+import pytest
+
+from datalad_registry.models import URL, URLMetadata, db
+from datalad_registry.tasks import extract_ds_meta, process_dataset_url
+
+from . import TEST_MIN_REPO_URL
+
+_BASIC_EXTRACTOR = "metalad_core"
+
+
+@pytest.fixture
+def processed_ds_urls(flask_app, two_files_ds_annex) -> list[int]:
+    """
+    Add valid dataset URLs to the database, process them, and return their IDs,
+    the primary keys
+    """
+
+    urls = [URL(url=TEST_MIN_REPO_URL), URL(url=two_files_ds_annex.path)]
+
+    with flask_app.app_context():
+        for url in urls:
+            db.session.add(url)
+        db.session.commit()
+
+        for url in urls:
+            process_dataset_url(url.id)
+
+        return [url.id for url in urls]
+
+
+class TestExtractDsMeta:
+    @pytest.mark.usefixtures("populate_db_with_unprocessed_dataset_urls")
+    @pytest.mark.parametrize("url_id", [1, 7, 10])
+    def test_nonexistent_ds_url(self, url_id, flask_app):
+        """
+        Test the case that the given dataset URL ID argument has no corresponding
+        dataset URL in the database
+        """
+        with flask_app.app_context():
+            with pytest.raises(ValueError):
+                extract_ds_meta(url_id, _BASIC_EXTRACTOR)
+
+    @pytest.mark.usefixtures("populate_db_with_unprocessed_dataset_urls")
+    @pytest.mark.parametrize("url_id", [2, 3, 4, 5, 6])
+    def test_unprocessed_ds_url(self, url_id, flask_app):
+        """
+        Test the case that the specified dataset URL, by ID, has not been processed
+        """
+        with flask_app.app_context():
+            with pytest.raises(ValueError):
+                extract_ds_meta(url_id, _BASIC_EXTRACTOR)
+
+    @pytest.mark.usefixtures("populate_db_with_unprocessed_dataset_urls")
+    @pytest.mark.parametrize("url_id", [2, 3, 4, 5, 6])
+    def test_processed_ds_url_without_cache_path(self, url_id, flask_app):
+        """
+        Test the case that the specified dataset URL, by ID, has been processed but
+        has no cache path
+        """
+        with flask_app.app_context():
+            url = db.session.execute(
+                db.select(URL).where(URL.id == url_id)
+            ).scalar_one()
+            url.processed = True
+
+            with pytest.raises(AssertionError):
+                extract_ds_meta(url_id, _BASIC_EXTRACTOR)
+
+    def test_valid_ds_url_for_metadata_extraction(self, processed_ds_urls, flask_app):
+        """
+        Test the case that the specified dataset URL, by ID, is valid for metadata
+        extraction
+        """
+
+        with flask_app.app_context():
+            for url_id in processed_ds_urls:
+                extract_ds_meta(url_id, _BASIC_EXTRACTOR)
+
+            # Confirm that the dataset URLs metadata have been extracted
+            for url_id in processed_ds_urls:
+                res = db.session.execute(
+                    db.select(URLMetadata.extractor_name).filter_by(url_id=url_id)
+                ).all()
+
+                assert len(res) == 1
+                assert res[0][0] == _BASIC_EXTRACTOR

--- a/datalad_registry/tests/test_new_organization/test_tasks/test_process_dataset_url.py
+++ b/datalad_registry/tests/test_new_organization/test_tasks/test_process_dataset_url.py
@@ -11,8 +11,6 @@ from sqlalchemy import inspect
 from datalad_registry.models import URL, db
 from datalad_registry.tasks import process_dataset_url
 
-_TEST_MIN_REPO_URL = "https://github.com/datalad/testrepo--minimalds.git"
-
 
 def is_there_file_in_tree(top: Union[Path, str]) -> bool:
     """
@@ -53,34 +51,6 @@ def is_dataset_url_unprocessed(dataset_url_id: int) -> bool:
     return (not dataset_url.processed) and all(
         getattr(dataset_url, f) is None for f in default_none_fields
     )
-
-
-@pytest.fixture
-def populate_db_with_unprocessed_dataset_urls(
-    flask_app,
-    empty_ds_annex,
-    empty_ds_non_annex,
-    two_files_ds_annex,
-    two_files_ds_non_annex,
-):
-    """
-    Populate the database with unprocessed dataset URLs
-    """
-
-    with flask_app.app_context():
-        non_dataset_url = URL(url="https://www.datalad.org/")
-        db.session.add(non_dataset_url)  # id == 1
-
-        db.session.add(URL(url=_TEST_MIN_REPO_URL))  # id == 2
-        db.session.add(URL(url=empty_ds_annex.path))  # id == 3
-        db.session.add(URL(url=empty_ds_non_annex.path))  # id == 4
-        db.session.add(URL(url=two_files_ds_annex.path))  # id == 5
-        db.session.add(URL(url=two_files_ds_non_annex.path))  # id == 6
-
-        db.session.commit()
-
-        db.session.delete(non_dataset_url)
-        db.session.commit()  # 1 is no longer a valid dataset URL id
 
 
 class TestProcessDatasetUrl:


### PR DESCRIPTION
Modify the Datalad-registry client to adopt API V2 of Datalad-registry.

This PR closes https://github.com/datalad/datalad-registry/issues/164 