### PR TITLE
Enable retrying for processing dataset URLs

### DIFF
--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -543,7 +543,7 @@ def extract_ds_meta(ds_url_id: StrictInt, extractor: StrictStr) -> ExtractMetaSt
     return extract_meta.run(ds_url_id, cache_path_abs, extractor)
 
 
-@celery.task
+@celery.task(autoretry_for=(IncompleteResultsError,), max_retries=4, retry_backoff=100)
 @validate_arguments
 def process_dataset_url(dataset_url_id: StrictInt) -> None:
     """


### PR DESCRIPTION
Enable retrying for the processing of dataset URLs should it encounters `datalad.support.exceptions.IncompleteResultsError`.  `datalad.support.exceptions.IncompleteResultsError` can arise in the process cloning of a dataset. It can possibly arise in the gathering of basic information about a dataset URL as well. In any case, the processing of dataset URLs, `process_dataset_url`, is idempotent and can safely retried.

This PR closes https://github.com/datalad/datalad-registry/issues/169.