### PR TITLE
Mark idempotent tasks to acknowledge late

### DIFF
--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -543,7 +543,12 @@ def extract_ds_meta(ds_url_id: StrictInt, extractor: StrictStr) -> ExtractMetaSt
     return extract_meta.run(ds_url_id, cache_path_abs, extractor)
 
 
-@celery.task(autoretry_for=(IncompleteResultsError,), max_retries=4, retry_backoff=100)
+@celery.task(
+    acks_late=True,  # `acks_late` is set. Make sure this task is always idempotent
+    autoretry_for=(IncompleteResultsError,),
+    max_retries=4,
+    retry_backoff=100,
+)
 @validate_arguments
 def process_dataset_url(dataset_url_id: StrictInt) -> None:
     """

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -500,7 +500,8 @@ def extract_meta(url_id: int, dataset_path: str, extractor: str) -> ExtractMetaS
         )
 
 
-@celery.task
+# `acks_late` is set. Make sure this task is always idempotent
+@celery.task(acks_late=True)
 @validate_arguments
 def extract_ds_meta(ds_url_id: StrictInt, extractor: StrictStr) -> ExtractMetaStatus:
     """


### PR DESCRIPTION
This PR marks idempotent Celery tasks to acknowledge after each task has been executed, not to acknowledge immediately before the task starts executing (the default behavior). Doing so increases the reliability of idempotent Celery tasks by ensuring their execution after the crash of a Celery worker and help the developer identify which Celery tasks are idempotent.

More information can be found at https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.acks_late and https://docs.celeryq.dev/en/stable/faq.html#faq-acks-late-vs-retry.

This PR depends on #170.