### PR TITLE
Disable Celery scheduler

### DIFF
--- a/datalad_registry/factory.py
+++ b/datalad_registry/factory.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 from celery.app.base import Celery
-from celery.schedules import crontab
 from flask import Flask, request
 from flask.logging import default_handler
 from flask_openapi3 import Info, OpenAPI
@@ -31,12 +30,7 @@ def _setup_logging(level: Union[int, str]) -> None:
 def setup_celery(app: Flask, celery: Celery) -> Celery:
     celery.conf.beat_schedule = {}
     cache_dir = app.config.get("DATALAD_REGISTRY_DATASET_CACHE")
-    if cache_dir:
-        celery.conf.beat_schedule["collect_dataset_info"] = {
-            "task": "datalad_registry.tasks.collect_dataset_info",
-            "schedule": crontab(minute="*/5"),
-        }
-    else:
+    if cache_dir is None:
         lgr.debug(
             "DATALAD_REGISTRY_DATASET_CACHE isn't configured. "
             "Not registering periodic tasks that depend on it"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,21 +49,24 @@ services:
       timeout: 3s
       retries: 10
 
-  scheduler:
-    build: .
-    depends_on:
-      broker:
-        condition: service_healthy
-    command: [
-      celery, -A, datalad_registry.runcelery.celery,
-      beat,
-      --loglevel, DEBUG,
-      -s, /app/instance/celerybeat-schedule
-    ]
-    volumes:
-      - ${DL_REGISTRY_INSTANCE_PATH}:/app/instance
-    environment:
-      <<: *env
+# TODO: Currently, there is no job to be scheduled.
+#   Disable this to make debugging easier.
+#   Once there is a job to be scheduled, we can uncomment this to enable the scheduler
+#  scheduler:
+#    build: .
+#    depends_on:
+#      broker:
+#        condition: service_healthy
+#    command: [
+#      celery, -A, datalad_registry.runcelery.celery,
+#      beat,
+#      --loglevel, DEBUG,
+#      -s, /app/instance/celerybeat-schedule
+#    ]
+#    volumes:
+#      - ${DL_REGISTRY_INSTANCE_PATH}:/app/instance
+#    environment:
+#      <<: *env
 
   broker:
     image: docker.io/rabbitmq:3-alpine


### PR DESCRIPTION
The old cron job of `collect_dataset_info` never worked, and it is not compatible with the new local cache organization. This PR removes the scheduling of `collect_dataset_info` and disable the scheduler service. The scheduler will be re-enabled once there is a job to be scheduled. For now, disabling it allows easier debugging of other services.