### PR TITLE
Feature: Add BIDS metadata extraction support

### DIFF
--- a/datalad_registry/config.py
+++ b/datalad_registry/config.py
@@ -27,6 +27,7 @@ class Config(object):
         "metalad_core",
         "metalad_studyminimeta",
         "datacite_gin",
+        "bids_dataset",
     ]
 
 

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -375,6 +375,7 @@ def update_url_info(ds_id: str, url: str) -> None:
 _EXTRACTOR_REQUIRED_FILES = {
     "metalad_studyminimeta": [".studyminimeta.yaml"],
     "datacite_gin": ["datacite.yml"],
+    "bids_dataset": ["dataset_description.json"],
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pydantic==1.10.4
 Flask-Migrate==4.0.4
 yarl==1.9.2
 datalad-catalog==0.2.1
+datalad_neuroimaging==0.3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     Flask-Migrate ~= 4.0
     yarl ~= 1.0
     datalad-catalog ~= 0.2.1
+    datalad_neuroimaging ~= 0.3.0
 
 packages = find:
 


### PR DESCRIPTION
Add extraction of BIDS metadata, as defined by the `bids_dataset` extractor  in `datalad_neuroimaging`  of registered URLs that meet the requirements of such extraction. This PR closes #141.

Additionally, this PR also updates the tool script of `populate_url_metadata.py` to populate the running instance of datalad-reistry on Typhon with the BIDS metadata.