### PR TITLE
Resolve additional potential circular imports

### DIFF
--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -46,7 +46,7 @@ class PathParams(BaseModel):
     id: int = Field(..., description="The ID of the dataset URL")
 
 
-class _QueryParams(BaseModel):
+class QueryParams(BaseModel):
     """
     Pydantic model for representing the query parameters to query
     the dataset_urls endpoint
@@ -208,7 +208,7 @@ def create_dataset_url(body: DatasetURLSubmitModel):
 
 
 @bp.get("", responses={"200": DatasetURLs})
-def dataset_urls(query: _QueryParams):
+def dataset_urls(query: QueryParams):
     """
     Get all dataset URLs that satisfy the constraints imposed by the query parameters.
     """

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -1,15 +1,10 @@
 # This file is for defining the API endpoints related to dataset URls
 
-from datetime import datetime
 import operator
-from pathlib import Path
-from typing import Optional, Union
-from uuid import UUID
 
 from celery import group
 from flask import abort, current_app
 from flask_openapi3 import APIBlueprint, Tag
-from pydantic import AnyUrl, BaseModel, Field, FileUrl, validator
 from sqlalchemy import and_
 from sqlalchemy.sql.elements import BinaryExpression
 
@@ -17,6 +12,13 @@ from datalad_registry.models import URL, db
 from datalad_registry.tasks import extract_ds_meta, log_error, process_dataset_url
 from datalad_registry.utils.flask_tools import json_resp_from_str
 
+from .models import (
+    DatasetURLRespModel,
+    DatasetURLs,
+    DatasetURLSubmitModel,
+    PathParams,
+    QueryParams,
+)
 from .. import API_URL_PREFIX, COMMON_API_RESPONSES, HTTPExceptionResp
 
 bp = APIBlueprint(
@@ -26,147 +28,6 @@ bp = APIBlueprint(
     abp_tags=[Tag(name="Dataset URLs", description="API endpoints for dataset URLs")],
     abp_responses=COMMON_API_RESPONSES,
 )
-
-
-def path_url_must_be_absolute(url):
-    """
-    Validator for the path URL field that ensures that the URL is absolute
-    """
-    if isinstance(url, Path) and not url.is_absolute():
-        raise ValueError("Path URLs must be absolute")
-    return url
-
-
-class PathParams(BaseModel):
-    """
-    Pydantic model for representing the path parameters for API endpoints related to
-    dataset URLs.
-    """
-
-    id: int = Field(..., description="The ID of the dataset URL")
-
-
-class QueryParams(BaseModel):
-    """
-    Pydantic model for representing the query parameters to query
-    the dataset_urls endpoint
-    """
-
-    url: Optional[Union[FileUrl, AnyUrl, Path]] = Field(None, description="The URL")
-
-    ds_id: Optional[UUID] = Field(None, description="The ID, a UUID, of the dataset")
-
-    min_annex_key_count: Optional[int] = Field(
-        None, description="The minimum number of annex keys "
-    )
-    max_annex_key_count: Optional[int] = Field(
-        None, description="The maximum number of annex keys "
-    )
-
-    min_annexed_files_in_wt_count: Optional[int] = Field(
-        None, description="The minimum number of annexed files in the working tree"
-    )
-    max_annexed_files_in_wt_count: Optional[int] = Field(
-        None, description="The maximum number of annexed files in the working tree"
-    )
-
-    min_annexed_files_in_wt_size: Optional[int] = Field(
-        None,
-        description="The minimum size of annexed files in the working tree in bytes",
-    )
-    max_annexed_files_in_wt_size: Optional[int] = Field(
-        None,
-        description="The maximum size of annexed files in the working tree in bytes",
-    )
-
-    earliest_last_update: Optional[datetime] = Field(
-        None,
-        description="The earliest last update time",
-    )
-    latest_last_update: Optional[datetime] = Field(
-        None,
-        description="The latest last update time",
-    )
-
-    min_git_objects_kb: Optional[int] = Field(
-        None, description="The minimum size of the `.git/objects` in KiB"
-    )
-    max_git_objects_kb: Optional[int] = Field(
-        None, description="The maximum size of the `.git/objects` in KiB"
-    )
-
-    processed: Optional[bool] = Field(
-        None,
-        description="Whether an initial processing has been completed "
-        "on the dataset URL",
-    )
-
-    # Validator
-    _path_url_must_be_absolute = validator("url", allow_reuse=True)(
-        path_url_must_be_absolute
-    )
-
-
-class DatasetURLSubmitModel(BaseModel):
-    """
-    Model for representing the database model URL for submission communication
-    """
-
-    url: Union[FileUrl, AnyUrl, Path] = Field(..., description="The URL")
-
-    # Validator
-    _path_url_must_be_absolute = validator("url", allow_reuse=True)(
-        path_url_must_be_absolute
-    )
-
-
-class DatasetURLRespModel(DatasetURLSubmitModel):
-    """
-    Model for representing the database model URL in response communication
-    """
-
-    id: int = Field(..., description="The ID of the dataset URL")
-    ds_id: Optional[UUID] = Field(
-        ..., alias="ds_id", description="The ID, a UUID, of the dataset"
-    )
-    describe: Optional[str] = Field(
-        ...,
-        alias="head_describe",
-        description="The output of `git describe --tags --always` on the dataset",
-    )
-    annex_key_count: Optional[int] = Field(..., description="The number of annex keys")
-    annexed_files_in_wt_count: Optional[int] = Field(
-        ..., description="The number of annexed files in the working tree"
-    )
-    annexed_files_in_wt_size: Optional[int] = Field(
-        ..., description="The size of annexed files in the working tree in bytes"
-    )
-    last_update: Optional[datetime] = Field(
-        ...,
-        alias="info_ts",
-        description="The last time the local copy of the dataset was updated",
-    )
-    git_objects_kb: Optional[int] = Field(
-        ..., description="The size of the `.git/objects` in KiB"
-    )
-    processed: bool = Field(
-        description="Whether an initial processing has been completed "
-        "on the dataset URL"
-    )
-
-    class Config:
-        orm_mode = True
-
-
-class DatasetURLs(BaseModel):
-    """
-    Model for representing a list of dataset URLs in response communication
-    """
-
-    __root__: list[DatasetURLRespModel]
-
-    class Config:
-        orm_mode = True
 
 
 @bp.post("", responses={"201": DatasetURLRespModel, "409": HTTPExceptionResp})

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -37,7 +37,7 @@ def path_url_must_be_absolute(url):
     return url
 
 
-class _PathParams(BaseModel):
+class PathParams(BaseModel):
     """
     Pydantic model for representing the path parameters for API endpoints related to
     dataset URLs.
@@ -272,7 +272,7 @@ def dataset_urls(query: _QueryParams):
 
 
 @bp.get("/<int:id>", responses={"200": DatasetURLRespModel})
-def dataset_url(path: _PathParams):
+def dataset_url(path: PathParams):
     """
     Get a dataset URL by ID.
     """

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -1,0 +1,147 @@
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Union
+from uuid import UUID
+
+from pydantic import AnyUrl, BaseModel, Field, FileUrl, validator
+
+
+def path_url_must_be_absolute(url):
+    """
+    Validator for the path URL field that ensures that the URL is absolute
+    """
+    if isinstance(url, Path) and not url.is_absolute():
+        raise ValueError("Path URLs must be absolute")
+    return url
+
+
+class PathParams(BaseModel):
+    """
+    Pydantic model for representing the path parameters for API endpoints related to
+    dataset URLs.
+    """
+
+    id: int = Field(..., description="The ID of the dataset URL")
+
+
+class QueryParams(BaseModel):
+    """
+    Pydantic model for representing the query parameters to query
+    the dataset_urls endpoint
+    """
+
+    url: Optional[Union[FileUrl, AnyUrl, Path]] = Field(None, description="The URL")
+
+    ds_id: Optional[UUID] = Field(None, description="The ID, a UUID, of the dataset")
+
+    min_annex_key_count: Optional[int] = Field(
+        None, description="The minimum number of annex keys "
+    )
+    max_annex_key_count: Optional[int] = Field(
+        None, description="The maximum number of annex keys "
+    )
+
+    min_annexed_files_in_wt_count: Optional[int] = Field(
+        None, description="The minimum number of annexed files in the working tree"
+    )
+    max_annexed_files_in_wt_count: Optional[int] = Field(
+        None, description="The maximum number of annexed files in the working tree"
+    )
+
+    min_annexed_files_in_wt_size: Optional[int] = Field(
+        None,
+        description="The minimum size of annexed files in the working tree in bytes",
+    )
+    max_annexed_files_in_wt_size: Optional[int] = Field(
+        None,
+        description="The maximum size of annexed files in the working tree in bytes",
+    )
+
+    earliest_last_update: Optional[datetime] = Field(
+        None,
+        description="The earliest last update time",
+    )
+    latest_last_update: Optional[datetime] = Field(
+        None,
+        description="The latest last update time",
+    )
+
+    min_git_objects_kb: Optional[int] = Field(
+        None, description="The minimum size of the `.git/objects` in KiB"
+    )
+    max_git_objects_kb: Optional[int] = Field(
+        None, description="The maximum size of the `.git/objects` in KiB"
+    )
+
+    processed: Optional[bool] = Field(
+        None,
+        description="Whether an initial processing has been completed "
+        "on the dataset URL",
+    )
+
+    # Validator
+    _path_url_must_be_absolute = validator("url", allow_reuse=True)(
+        path_url_must_be_absolute
+    )
+
+
+class DatasetURLSubmitModel(BaseModel):
+    """
+    Model for representing the database model URL for submission communication
+    """
+
+    url: Union[FileUrl, AnyUrl, Path] = Field(..., description="The URL")
+
+    # Validator
+    _path_url_must_be_absolute = validator("url", allow_reuse=True)(
+        path_url_must_be_absolute
+    )
+
+
+class DatasetURLRespModel(DatasetURLSubmitModel):
+    """
+    Model for representing the database model URL in response communication
+    """
+
+    id: int = Field(..., description="The ID of the dataset URL")
+    ds_id: Optional[UUID] = Field(
+        ..., alias="ds_id", description="The ID, a UUID, of the dataset"
+    )
+    describe: Optional[str] = Field(
+        ...,
+        alias="head_describe",
+        description="The output of `git describe --tags --always` on the dataset",
+    )
+    annex_key_count: Optional[int] = Field(..., description="The number of annex keys")
+    annexed_files_in_wt_count: Optional[int] = Field(
+        ..., description="The number of annexed files in the working tree"
+    )
+    annexed_files_in_wt_size: Optional[int] = Field(
+        ..., description="The size of annexed files in the working tree in bytes"
+    )
+    last_update: Optional[datetime] = Field(
+        ...,
+        alias="info_ts",
+        description="The last time the local copy of the dataset was updated",
+    )
+    git_objects_kb: Optional[int] = Field(
+        ..., description="The size of the `.git/objects` in KiB"
+    )
+    processed: bool = Field(
+        description="Whether an initial processing has been completed "
+        "on the dataset URL"
+    )
+
+    class Config:
+        orm_mode = True
+
+
+class DatasetURLs(BaseModel):
+    """
+    Model for representing a list of dataset URLs in response communication
+    """
+
+    __root__: list[DatasetURLRespModel]
+
+    class Config:
+        orm_mode = True

--- a/datalad_registry/blueprints/api/url_metadata/__init__.py
+++ b/datalad_registry/blueprints/api/url_metadata/__init__.py
@@ -2,10 +2,10 @@
 # i.e. the metadata of datasets at individual URLs.
 
 from flask_openapi3 import APIBlueprint, Tag
-from pydantic import BaseModel, Field, StrictStr
 
 from datalad_registry.models import URLMetadata, db
 
+from .models import PathParams, URLMetadataModel
 from .. import API_URL_PREFIX, COMMON_API_RESPONSES
 
 bp = APIBlueprint(
@@ -15,31 +15,6 @@ bp = APIBlueprint(
     abp_tags=[Tag(name="URL Metadata", description="API endpoints for URL metadata")],
     abp_responses=COMMON_API_RESPONSES,
 )
-
-
-class PathParams(BaseModel):
-    """
-    Pydantic model for representing the path parameters for the URL metadata API
-    endpoints.
-    """
-
-    url_metadata_id: int = Field(..., description="The ID of the URL metadata")
-
-
-class URLMetadataModel(BaseModel):
-    """
-    Model for representing the database model URLMetadata for communication
-    """
-
-    dataset_describe: StrictStr
-    dataset_version: StrictStr
-    extractor_name: StrictStr
-    extractor_version: StrictStr
-    extraction_parameter: dict
-    extracted_metadata: dict
-
-    class Config:
-        orm_mode = True
 
 
 @bp.get("/<int:url_metadata_id>", responses={"200": URLMetadataModel})

--- a/datalad_registry/blueprints/api/url_metadata/__init__.py
+++ b/datalad_registry/blueprints/api/url_metadata/__init__.py
@@ -17,7 +17,7 @@ bp = APIBlueprint(
 )
 
 
-class _PathParams(BaseModel):
+class PathParams(BaseModel):
     """
     Pydantic model for representing the path parameters for the URL metadata API
     endpoints.
@@ -43,7 +43,7 @@ class URLMetadataModel(BaseModel):
 
 
 @bp.get("/<int:url_metadata_id>", responses={"200": URLMetadataModel})
-def url_metadata(path: _PathParams):
+def url_metadata(path: PathParams):
     """
     Get URL metadata by ID.
     """

--- a/datalad_registry/blueprints/api/url_metadata/models.py
+++ b/datalad_registry/blueprints/api/url_metadata/models.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, Field, StrictStr
+
+
+class PathParams(BaseModel):
+    """
+    Pydantic model for representing the path parameters for the URL metadata API
+    endpoints.
+    """
+
+    url_metadata_id: int = Field(..., description="The ID of the URL metadata")
+
+
+class URLMetadataModel(BaseModel):
+    """
+    Model for representing the database model URLMetadata for communication
+    """
+
+    dataset_describe: StrictStr
+    dataset_version: StrictStr
+    extractor_name: StrictStr
+    extractor_version: StrictStr
+    extraction_parameter: dict
+    extracted_metadata: dict
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
The PR extract models in `dataset_urls` and `url_metadata` and put them in separate files. This eliminates circular imports caused by using these models by external code that also defines the `datalad.api` dynamically.

This PR closes #177. 