### PR TITLE
Add test for registering of `registry_submit_urls`

### DIFF
--- a/datalad_registry_client/tests/test_submit_urls.py
+++ b/datalad_registry_client/tests/test_submit_urls.py
@@ -6,6 +6,15 @@ import requests
 from datalad_registry_client import DEFAULT_BASE_ENDPOINT
 
 
+def test_register():
+    """
+    Test that `registry_submit_urls` is registered with DataLad.
+    """
+    import datalad.api as ds
+
+    assert hasattr(ds, "registry_submit_urls")
+
+
 class MockResponse:
     """
     Custom class used to mock the response object returned by


### PR DESCRIPTION
This PR provides a test for verifying the `registry_submit_urls` command is indeed registered with the Datalad API