### PR TITLE
Feature: Make metadata available through the dataset URLs API endpoint

### DIFF
--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -179,7 +179,7 @@ def dataset_urls(query: QueryParams):
     else:
         # === Metadata should be returned by content ===
 
-        ds_urls = DatasetURLs.from_orm(orm_ds_urls)
+        ds_urls = DatasetURLs.parse_obj(orm_ds_urls)
 
     return json_resp_from_str(ds_urls.json())
 

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -4,7 +4,7 @@ import operator
 from pathlib import Path
 
 from celery import group
-from flask import abort, current_app
+from flask import abort, current_app, url_for
 from flask_openapi3 import APIBlueprint, Tag
 from sqlalchemy import and_
 from sqlalchemy.sql.elements import BinaryExpression
@@ -14,13 +14,16 @@ from datalad_registry.tasks import extract_ds_meta, log_error, process_dataset_u
 from datalad_registry.utils.flask_tools import json_resp_from_str
 
 from .models import (
+    DatasetURLRespBaseModel,
     DatasetURLRespModel,
     DatasetURLs,
     DatasetURLSubmitModel,
+    MetadataReturnOption,
     PathParams,
     QueryParams,
 )
 from .. import API_URL_PREFIX, COMMON_API_RESPONSES, HTTPExceptionResp
+from ..url_metadata.models import URLMetadataRef
 
 bp = APIBlueprint(
     "dataset_urls_api",
@@ -136,11 +139,48 @@ def dataset_urls(query: QueryParams):
 
     # ==== Gathering constraints from query parameters ends ====
 
-    ds_urls = DatasetURLs.from_orm(
+    orm_ds_urls = (
         db.session.execute(db.select(URL).filter(and_(True, *constraints)))
         .scalars()
         .all()
     )
+
+    if query.return_metadata is None:
+        # === No metadata should be returned ===
+
+        ds_urls = DatasetURLs.parse_obj(
+            [
+                DatasetURLRespModel(
+                    **DatasetURLRespBaseModel.from_orm(i).dict(), metadata=None
+                )
+                for i in orm_ds_urls
+            ]
+        )
+    elif query.return_metadata is MetadataReturnOption.reference:
+        # === Metadata should be returned by reference ===
+
+        ds_urls = DatasetURLs.parse_obj(
+            [
+                DatasetURLRespModel(
+                    **DatasetURLRespBaseModel.from_orm(i).dict(),
+                    metadata=[
+                        URLMetadataRef(
+                            extractor_name=j.extractor_name,
+                            link=url_for(
+                                "url_metadata_api.url_metadata", url_metadata_id=j.id
+                            ),
+                        )
+                        for j in i.metadata_
+                    ],
+                )
+                for i in orm_ds_urls
+            ]
+        )
+    else:
+        # === Metadata should be returned by content ===
+
+        ds_urls = DatasetURLs.from_orm(orm_ds_urls)
+
     return json_resp_from_str(ds_urls.json())
 
 

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -148,10 +148,11 @@ def dataset_urls(query: QueryParams):
     if query.return_metadata is None:
         # === No metadata should be returned ===
 
+        # noinspection PyArgumentList
         ds_urls = DatasetURLs.parse_obj(
             [
                 DatasetURLRespModel(
-                    **DatasetURLRespBaseModel.from_orm(i).dict(), metadata=None
+                    **DatasetURLRespBaseModel.from_orm(i).dict(), metadata_=None
                 )
                 for i in orm_ds_urls
             ]
@@ -159,11 +160,12 @@ def dataset_urls(query: QueryParams):
     elif query.return_metadata is MetadataReturnOption.reference:
         # === Metadata should be returned by reference ===
 
+        # noinspection PyArgumentList
         ds_urls = DatasetURLs.parse_obj(
             [
                 DatasetURLRespModel(
                     **DatasetURLRespBaseModel.from_orm(i).dict(),
-                    metadata=[
+                    metadata_=[
                         URLMetadataRef(
                             extractor_name=j.extractor_name,
                             link=url_for(

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -104,19 +104,16 @@ class QueryParams(BaseModel):
 
     return_metadata: Optional[MetadataReturnOption] = Field(
         None,
-        # todo: description to be modified
         description="Whether and how to return metadata of the datasets at the URLs. "
         "If this query parameter is not provided, the `metadata` field "
         "of each returned dataset URL object will be `null`. "
         'If this query parameter is "reference", '
-        "the `metadata` field of each returned dataset URL object will be "
-        "an object with metadata extractor names being the fields and "
-        "the links to the corresponding metadata being the values. "
+        "the `metadata` field of each returned dataset URL object will be a list of "
+        "objects each presenting a reference link to a piece of metadata "
+        "of the dataset at the URL. "
         'If this query parameter is "content", the `metadata` field '
-        "of each returned dataset URL object will be an object "
-        "with metadata extractor names being the fields "
-        "and objects representing the corresponding metadata "
-        "being the values.",
+        "of each returned dataset URL object will be a list of objects "
+        "each presenting a piece of metadata of the dataset at the URL.",
     )
 
     # Validator

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -7,7 +7,7 @@ from pydantic import AnyUrl, BaseModel, Field, FileUrl, validator
 
 from datalad_registry.utils import StrEnum
 
-from ..url_metadata.models import URLMetadataModel
+from ..url_metadata.models import URLMetadataModel, URLMetadataRef
 
 
 def path_url_must_be_absolute(url):
@@ -184,7 +184,7 @@ class DatasetURLRespModel(DatasetURLRespBaseModel):
     Model for representing the database model URL in response communication
     """
 
-    metadata: Optional[Union[list[URLMetadataModel], list[int]]] = Field(
+    metadata: Optional[Union[list[URLMetadataModel], list[URLMetadataRef]]] = Field(
         ..., alias="metadata_", description="The metadata of the dataset at the URL"
     )
 

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -194,5 +194,5 @@ class DatasetURLs(BaseModel):
 
     __root__: list[DatasetURLRespModel]
 
-    def __iter__(self) -> Iterator[DatasetURLRespModel]:
+    def __iter__(self) -> Iterator[DatasetURLRespModel]:  # type: ignore[override]
         return iter(self.__root__)

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -103,6 +103,7 @@ class QueryParams(BaseModel):
 
     return_metadata: Optional[MetadataReturnOption] = Field(
         None,
+        # todo: description to be modified
         description="Whether and how to return metadata of the datasets at the URLs. "
         "If this query parameter is not provided, the `metadata` field "
         "of each returned dataset URL object will be `null`. "

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -136,9 +136,12 @@ class DatasetURLSubmitModel(BaseModel):
     )
 
 
-class DatasetURLRespModel(DatasetURLSubmitModel):
+class DatasetURLRespBaseModel(DatasetURLSubmitModel):
     """
-    Model for representing the database model URL in response communication
+    Base model for `DatasetURLRespModel`
+
+    All fields defined in this model are intended to be populated
+    from an orm model object directly.
     """
 
     id: int = Field(..., description="The ID of the dataset URL")
@@ -169,13 +172,20 @@ class DatasetURLRespModel(DatasetURLSubmitModel):
         description="Whether an initial processing has been completed "
         "on the dataset URL"
     )
-    metadata: Optional[list[URLMetadataModel]] = Field(
-        None, description="The metadata of the dataset at the URL"
-    )
 
     class Config:
         orm_mode = True
         allow_population_by_field_name = True
+
+
+class DatasetURLRespModel(DatasetURLRespBaseModel):
+    """
+    Model for representing the database model URL in response communication
+    """
+
+    metadata: Optional[list[URLMetadataModel]] = Field(
+        None, description="The metadata of the dataset at the URL"
+    )
 
 
 class DatasetURLs(BaseModel):

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -184,7 +184,7 @@ class DatasetURLRespModel(DatasetURLRespBaseModel):
     """
 
     metadata: Optional[list[URLMetadataModel]] = Field(
-        None, description="The metadata of the dataset at the URL"
+        None, alias="metadata_", description="The metadata of the dataset at the URL"
     )
 
 

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -184,7 +184,7 @@ class DatasetURLRespModel(DatasetURLRespBaseModel):
     Model for representing the database model URL in response communication
     """
 
-    metadata: Optional[list[URLMetadataModel]] = Field(
+    metadata: Optional[Union[list[URLMetadataModel], list[int]]] = Field(
         ..., alias="metadata_", description="The metadata of the dataset at the URL"
     )
 

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -5,6 +5,8 @@ from uuid import UUID
 
 from pydantic import AnyUrl, BaseModel, Field, FileUrl, validator
 
+from datalad_registry.utils import StrEnum
+
 
 def path_url_must_be_absolute(url):
     """
@@ -13,6 +15,15 @@ def path_url_must_be_absolute(url):
     if isinstance(url, Path) and not url.is_absolute():
         raise ValueError("Path URLs must be absolute")
     return url
+
+
+class MetadataReturnOption(StrEnum):
+    """
+    Enum for representing the metadata return options
+    """
+
+    references = "references"
+    content = "content"
 
 
 class PathParams(BaseModel):

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -184,7 +184,7 @@ class DatasetURLRespModel(DatasetURLRespBaseModel):
     """
 
     metadata: Optional[list[URLMetadataModel]] = Field(
-        None, alias="metadata_", description="The metadata of the dataset at the URL"
+        ..., alias="metadata_", description="The metadata of the dataset at the URL"
     )
 
 

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -7,6 +7,8 @@ from pydantic import AnyUrl, BaseModel, Field, FileUrl, validator
 
 from datalad_registry.utils import StrEnum
 
+from ..url_metadata.models import URLMetadataModel
+
 
 def path_url_must_be_absolute(url):
     """
@@ -166,6 +168,9 @@ class DatasetURLRespModel(DatasetURLSubmitModel):
     processed: bool = Field(
         description="Whether an initial processing has been completed "
         "on the dataset URL"
+    )
+    metadata: list[URLMetadataModel] = Field(
+        ..., alias="metadata_", description="The metadata of the dataset at the URL"
     )
 
     class Config:

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -195,6 +195,3 @@ class DatasetURLs(BaseModel):
     """
 
     __root__: list[DatasetURLRespModel]
-
-    class Config:
-        orm_mode = True

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -169,8 +169,8 @@ class DatasetURLRespModel(DatasetURLSubmitModel):
         description="Whether an initial processing has been completed "
         "on the dataset URL"
     )
-    metadata: list[URLMetadataModel] = Field(
-        ..., alias="metadata_", description="The metadata of the dataset at the URL"
+    metadata: Optional[list[URLMetadataModel]] = Field(
+        None, description="The metadata of the dataset at the URL"
     )
 
     class Config:

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, Union
@@ -195,3 +196,6 @@ class DatasetURLs(BaseModel):
     """
 
     __root__: list[DatasetURLRespModel]
+
+    def __iter__(self) -> Iterator[DatasetURLRespModel]:
+        return iter(self.__root__)

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -99,6 +99,22 @@ class QueryParams(BaseModel):
         "in the query.",
     )
 
+    return_metadata: Optional[MetadataReturnOption] = Field(
+        None,
+        description="Whether and how to return metadata of the datasets at the URLs. "
+        "If this query parameter is not provided, the `metadata` field "
+        "of each returned dataset URL object will be `null`. "
+        'If this query parameter is "references", '
+        "the `metadata` field of each returned dataset URL object will be "
+        "an object with metadata extractor names being the fields and "
+        "the links to the corresponding metadata being the values. "
+        'If this query parameter is "content", the `metadata` field '
+        "of each returned dataset URL object will be an object "
+        "with metadata extractor names being the fields "
+        "and objects representing the corresponding metadata "
+        "being the values.",
+    )
+
     # Validator
     _path_url_must_be_absolute = validator("url", allow_reuse=True)(
         path_url_must_be_absolute

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -24,7 +24,7 @@ class MetadataReturnOption(StrEnum):
     Enum for representing the metadata return options
     """
 
-    references = "references"
+    reference = "reference"
     content = "content"
 
 
@@ -107,7 +107,7 @@ class QueryParams(BaseModel):
         description="Whether and how to return metadata of the datasets at the URLs. "
         "If this query parameter is not provided, the `metadata` field "
         "of each returned dataset URL object will be `null`. "
-        'If this query parameter is "references", '
+        'If this query parameter is "reference", '
         "the `metadata` field of each returned dataset URL object will be "
         "an object with metadata extractor names being the fields and "
         "the links to the corresponding metadata being the values. "

--- a/datalad_registry/blueprints/api/url_metadata/models.py
+++ b/datalad_registry/blueprints/api/url_metadata/models.py
@@ -10,14 +10,21 @@ class PathParams(BaseModel):
     url_metadata_id: int = Field(..., description="The ID of the URL metadata")
 
 
-class URLMetadataModel(BaseModel):
+class _URLMetadataRep(BaseModel):
+    """
+    Base model for representing metadata of a dataset at a URL
+    """
+
+    extractor_name: StrictStr
+
+
+class URLMetadataModel(_URLMetadataRep):
     """
     Model for representing the database model URLMetadata for communication
     """
 
     dataset_describe: StrictStr
     dataset_version: StrictStr
-    extractor_name: StrictStr
     extractor_version: StrictStr
     extraction_parameter: dict
     extracted_metadata: dict
@@ -26,11 +33,10 @@ class URLMetadataModel(BaseModel):
         orm_mode = True
 
 
-class URLMetadataRef(BaseModel):
+class URLMetadataRef(_URLMetadataRep):
     """
     Model for referencing metadata of a dataset at a URL extracted by an extractor
     through the API
     """
 
-    extractor_name: StrictStr
-    link: StrictStr  # This link is relative
+    link: StrictStr

--- a/datalad_registry/blueprints/api/url_metadata/models.py
+++ b/datalad_registry/blueprints/api/url_metadata/models.py
@@ -24,3 +24,13 @@ class URLMetadataModel(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class URLMetadataRef(BaseModel):
+    """
+    Model for referencing metadata of a dataset at a URL extracted by an extractor
+    through the API
+    """
+
+    extractor_name: StrictStr
+    link: StrictStr  # This link is relative

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -225,6 +225,9 @@ class TestDatasetURLs:
             {"min_git_objects_kb": 40},
             {"max_git_objects_kb": "100"},
             {"processed": True},
+            {"return_metadata": None},
+            {"return_metadata": MetadataReturnOption.reference.value},
+            {"return_metadata": MetadataReturnOption.content.value},
         ],
     )
     def test_valid_query_params(self, flask_client, query_params):

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -202,6 +202,7 @@ class TestDatasetURLs:
             {"min_git_objects_kb": "lmn"},
             {"max_git_objects_kb": "mno"},
             {"processed": "nop"},
+            {"return_metadata": "all"},
         ],
     )
     def test_invalid_query_params(self, flask_client, query_params):

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 
 from datalad_registry.blueprints.api.dataset_urls import DatasetURLRespModel
+from datalad_registry.models import URL, db
 
 
 @pytest.fixture
@@ -10,7 +11,6 @@ def populate_with_2_dataset_urls(flask_app):
     """
     Populate the url table with 2 URLs, at position 1 and 3.
     """
-    from datalad_registry.models import URL, db
 
     dataset_url1 = URL(url="https://example.com")
     dataset_url2 = URL(url="https://docs.datalad.org")
@@ -30,7 +30,6 @@ def populate_with_dataset_urls(flask_app):
     """
     Populate the url table with a list of URLs.
     """
-    from datalad_registry.models import URL, db
 
     urls = [
         URL(

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 
 from datalad_registry.blueprints.api.dataset_urls import DatasetURLRespModel
-from datalad_registry.models import URL, db
+from datalad_registry.models import URL, URLMetadata, db
 
 
 @pytest.fixture
@@ -78,6 +78,50 @@ def populate_with_dataset_urls(flask_app):
     with flask_app.app_context():
         for url in urls:
             db.session.add(url)
+        db.session.commit()
+
+
+@pytest.fixture
+def populate_with_url_metadata(
+    populate_with_dataset_urls,  # noqa: U100 (unused argument)
+    flask_app,
+):
+    """
+    Populate the url_metadata table with a list of metadata
+    """
+    metadata_lst = [
+        URLMetadata(
+            dataset_describe="1234",
+            dataset_version="1.0.0",
+            extractor_name="metalad_core",
+            extractor_version="0.14.0",
+            extraction_parameter=dict(a=1, b=2),
+            extracted_metadata=dict(c=3, d=4),
+            url_id=1,
+        ),
+        URLMetadata(
+            dataset_describe="1234",
+            dataset_version="1.0.0",
+            extractor_name="metalad_studyminimet",
+            extractor_version="0.1.0",
+            extraction_parameter=dict(a=1, b=2),
+            extracted_metadata=dict(c=3, d=4),
+            url_id=1,
+        ),
+        URLMetadata(
+            dataset_describe="1234",
+            dataset_version="1.0.0",
+            extractor_name="metalad_core",
+            extractor_version="0.14.0",
+            extraction_parameter=dict(a=1, b=2),
+            extracted_metadata=dict(c=3, d=4),
+            url_id=3,
+        ),
+    ]
+
+    with flask_app.app_context():
+        for metadata in metadata_lst:
+            db.session.add(metadata)
         db.session.commit()
 
 

--- a/datalad_registry_client/tests/test_get_urls.py
+++ b/datalad_registry_client/tests/test_get_urls.py
@@ -35,6 +35,7 @@ dataset_url_resp_model_template = dict(
     last_update=datetime(2008, 7, 18, 18, 34, 32),
     git_objects_kb=1200,
     processed=True,
+    metadata=[],
 )
 
 


### PR DESCRIPTION
This PR closes #176.

This PR adds the query parameter of `return_metadata` to the `GET /api/v2/dataset-urls` endpoint. If this query parameter is not provided, the `metadata` field of each returned dataset URL object will be `null`. If this query parameter is "reference", the `metadata` field of each returned dataset URL object will be a list of objects each presenting a reference link to a piece of metadata of the dataset at the URL. If this query parameter is "content", the `metadata` field of each returned dataset URL object will be a list of objects each presenting a piece of metadata of the dataset at the URL.

Note: I used "reference" instead of "references" as a value of `return_metadata` because I feel that this value is an adjective pertaining to how each piece of metadata should be returned.