### PR TITLE
Rename `OrderKey.git_objects_size` to `OrderKey.git_objects_kb`

### DIFF
--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -33,7 +33,7 @@ _ORDER_KEY_TO_SQLA_ATTR = {
     OrderKey.annexed_files_in_wt_count: URL.annexed_files_in_wt_count,
     OrderKey.annexed_files_in_wt_size: URL.annexed_files_in_wt_size,
     OrderKey.last_update: URL.info_ts,
-    OrderKey.git_objects_size: URL.git_objects_kb,
+    OrderKey.git_objects_kb: URL.git_objects_kb,
 }
 
 bp = APIBlueprint(

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -47,7 +47,7 @@ class OrderKey(StrEnum):
     annexed_files_in_wt_count = "annexed_files_in_wt_count"
     annexed_files_in_wt_size = "annexed_files_in_wt_size"
     last_update = "last_update"
-    git_objects_size = "git_objects_size"
+    git_objects_kb = "git_objects_kb"
 
 
 class MetadataReturnOption(StrEnum):

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -252,7 +252,7 @@ class TestDatasetURLs:
             {"order_by": "annexed_files_in_wt_count"},
             {"order_by": "annexed_files_in_wt_size"},
             {"order_by": "last_update"},
-            {"order_by": "git_objects_size"},
+            {"order_by": "git_objects_kb"},
             {"order_dir": "asc"},
             {"order_dir": "desc"},
         ],
@@ -540,7 +540,7 @@ class TestDatasetURLs:
             ),
             (
                 {
-                    "order_by": "git_objects_size",
+                    "order_by": "git_objects_kb",
                     "order_dir": "desc",
                     "per_page": 1,
                 },
@@ -548,7 +548,7 @@ class TestDatasetURLs:
             ),
             (
                 {
-                    "order_by": "git_objects_size",
+                    "order_by": "git_objects_kb",
                     "per_page": 1,
                 },
                 [3, 2, 1, 4],


### PR DESCRIPTION
This PR renames `OrderKey.git_objects_size` to `OrderKey.git_objects_kb` per @yarikoptic's [suggestion](`OrderKey.git_objects_size` to `OrderKey.git_objects_kb`).