### PR TITLE
Improvement: Skip `null` fields in API responses

### DIFF
--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -75,7 +75,9 @@ def create_dataset_url(body: DatasetURLSubmitModel):
         ]
         (url_processing | group(meta_extractions)).apply_async()
 
-        return json_resp_from_str(DatasetURLRespModel.from_orm(url).json(), 201)
+        return json_resp_from_str(
+            DatasetURLRespModel.from_orm(url).json(exclude_none=True), 201
+        )
 
     else:
         # == The URL requested to be created already exists in the database ==
@@ -222,7 +224,7 @@ def dataset_urls(query: QueryParams):
         dataset_urls=ds_urls,
     )
 
-    return json_resp_from_str(page.json())
+    return json_resp_from_str(page.json(exclude_none=True))
 
 
 @bp.get("/<int:id>", responses={"200": DatasetURLRespModel})
@@ -231,4 +233,4 @@ def dataset_url(path: PathParams):
     Get a dataset URL by ID.
     """
     ds_url = DatasetURLRespModel.from_orm(db.get_or_404(URL, path.id))
-    return json_resp_from_str(ds_url.json())
+    return json_resp_from_str(ds_url.json(exclude_none=True))

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -135,8 +135,8 @@ class QueryParams(BaseModel):
     return_metadata: Optional[MetadataReturnOption] = Field(
         None,
         description="Whether and how to return metadata of the datasets at the URLs. "
-        "If this query parameter is not provided, the `metadata` field "
-        "of each returned dataset URL object will be `null`. "
+        "If this query parameter is not provided, "
+        "each returned dataset URL object will not contain a `metadata` field. "
         'If this query parameter is "reference", '
         "the `metadata` field of each returned dataset URL object will be a list of "
         "objects each presenting a reference link to a piece of metadata "

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -196,27 +196,27 @@ class DatasetURLRespBaseModel(DatasetURLSubmitModel):
 
     id: int = Field(..., description="The ID of the dataset URL")
     ds_id: Optional[UUID] = Field(
-        ..., alias="ds_id", description="The ID, a UUID, of the dataset"
+        None, alias="ds_id", description="The ID, a UUID, of the dataset"
     )
     describe: Optional[str] = Field(
-        ...,
+        None,
         alias="head_describe",
         description="The output of `git describe --tags --always` on the dataset",
     )
-    annex_key_count: Optional[int] = Field(..., description="The number of annex keys")
+    annex_key_count: Optional[int] = Field(None, description="The number of annex keys")
     annexed_files_in_wt_count: Optional[int] = Field(
-        ..., description="The number of annexed files in the working tree"
+        None, description="The number of annexed files in the working tree"
     )
     annexed_files_in_wt_size: Optional[int] = Field(
-        ..., description="The size of annexed files in the working tree in bytes"
+        None, description="The size of annexed files in the working tree in bytes"
     )
     last_update: Optional[datetime] = Field(
-        ...,
+        None,
         alias="info_ts",
         description="The last time the local copy of the dataset was updated",
     )
     git_objects_kb: Optional[int] = Field(
-        ..., description="The size of the `.git/objects` in KiB"
+        None, description="The size of the `.git/objects` in KiB"
     )
     processed: bool = Field(
         description="Whether an initial processing has been completed "
@@ -234,7 +234,7 @@ class DatasetURLRespModel(DatasetURLRespBaseModel):
     """
 
     metadata: Optional[Union[list[URLMetadataModel], list[URLMetadataRef]]] = Field(
-        ..., alias="metadata_", description="The metadata of the dataset at the URL"
+        None, alias="metadata_", description="The metadata of the dataset at the URL"
     )
 
 
@@ -248,9 +248,9 @@ class DatasetURLPage(BaseModel):
     )
     cur_pg_num: StrictInt = Field(description="The number of the current page")
     prev_pg: Optional[StrictStr] = Field(
-        ..., description="The link to the previous page"
+        None, description="The link to the previous page"
     )
-    next_pg: Optional[StrictStr] = Field(..., description="The link to the next page")
+    next_pg: Optional[StrictStr] = Field(None, description="The link to the next page")
     first_pg: StrictStr = Field(description="The link to the first page")
     last_pg: StrictStr = Field(description="The link to the last page")
 

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -434,10 +434,12 @@ class TestDatasetURLs:
 
         assert resp.status_code == 200
 
-        ds_url_pg = DatasetURLPage.parse_raw(resp.text)
+        resp_json = resp.json
+        ds_url_pg = DatasetURLPage.parse_obj(resp_json)
 
         assert ds_url_pg.total == 4
         assert ds_url_pg.cur_pg_num == 1
+        assert "prev_pg" not in resp_json
         assert ds_url_pg.prev_pg is None
         assert ds_url_pg.next_pg is not None
 
@@ -470,11 +472,13 @@ class TestDatasetURLs:
 
         assert resp.status_code == 200
 
-        ds_url_pg = DatasetURLPage.parse_raw(resp.text)
+        resp_json = resp.json
+        ds_url_pg = DatasetURLPage.parse_obj(resp_json)
 
         assert ds_url_pg.total == 4
         assert ds_url_pg.cur_pg_num == 2
         assert ds_url_pg.prev_pg is not None
+        assert "next_pg" not in resp_json
         assert ds_url_pg.next_pg is None
 
         prev_pg_lk, first_pg_lk, last_pg_lk = (

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -166,18 +166,8 @@ class TestCreateDatasetURL:
         resp = flask_client.post("/api/v2/dataset-urls", json=request_json_body)
         assert resp.status_code == 201
 
-        resp_json_body = resp.json
-
-        # Ensure the keys of the JSON body of the response are the field names of
-        # DatasetURLRespModel
-        model_field_names = set(
-            DatasetURLRespModel.schema(by_alias=False)["properties"]
-        )
-        resp_json_body_keys = set(resp_json_body)
-        assert resp_json_body_keys == model_field_names
-
-        # Ensure the `processed` field is the default value of False
-        assert not resp_json_body["processed"]
+        # Ensure the response body is valid
+        DatasetURLRespModel.parse_raw(resp.text)
 
     @pytest.mark.usefixtures("populate_with_2_dataset_urls")
     @pytest.mark.parametrize(
@@ -622,15 +612,8 @@ class TestDatasetURL:
         resp = flask_client.get(f"/api/v2/dataset-urls/{dataset_url_id}")
         assert resp.status_code == 200
 
-        resp_json_body = resp.json
-
-        # Ensure the keys of the JSON body of the response are the field names of
-        # DatasetURLRespModel
-        model_field_names = set(
-            DatasetURLRespModel.schema(by_alias=False)["properties"]
-        )
-        resp_json_body_keys = set(resp_json_body)
-        assert resp_json_body_keys == model_field_names
+        # Ensure the response body is valid
+        ds_url = DatasetURLRespModel.parse_raw(resp.text)
 
         # Ensure the correct URL is fetched
-        assert resp_json_body["url"] == url
+        assert str(ds_url.url) == url

--- a/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_new_organization/test_blueprints/test_api/test_dataset_urls.py
@@ -394,12 +394,13 @@ class TestDatasetURLs:
 
         assert resp.status_code == 200
 
-        ds_url_pg = DatasetURLPage.parse_raw(resp.text)
+        resp_json = resp.json
+        ds_url_pg = DatasetURLPage.parse_obj(resp_json)
 
         if metadata_ret_opt is None:
             # === metadata is not returned ===
 
-            assert all(url.metadata is None for url in ds_url_pg.dataset_urls)
+            assert all("metadata" not in url for url in resp_json["dataset_urls"])
         else:
             # === metadata is returned ===
 

--- a/datalad_registry_client/tests/test_get_urls.py
+++ b/datalad_registry_client/tests/test_get_urls.py
@@ -90,7 +90,7 @@ class TestRegistryGetURLs:
                                 url="https://www.example.com"
                             )
                         ],
-                    ).json(),
+                    ).json(exclude_none=True),
                 )
             else:
                 return MockResponse(404, "Not Found")
@@ -141,7 +141,7 @@ class TestRegistryGetURLs:
                                 url="https://www.example.com"
                             )
                         ],
-                    ).json(),
+                    ).json(exclude_none=True),
                 )
             else:
                 return MockResponse(404, "Not Found")
@@ -193,7 +193,7 @@ class TestRegistryGetURLs:
             # noinspection PyTypeChecker
             return MockResponse(
                 200,
-                next(ds_url_pgs_iter).json(),
+                next(ds_url_pgs_iter).json(exclude_none=True),
             )
 
         monkeypatch.setattr(requests.Session, "get", mock_get)
@@ -249,7 +249,7 @@ class TestRegistryGetURLs:
                                 url="https://www.example.com"
                             )
                         ],
-                    ).json(),
+                    ).json(exclude_none=True),
                 )
 
         mock_resp_iter = mock_responses()


### PR DESCRIPTION
This PR modifies the API so that no field having the value of `null` will be returned as part of an API response. A field that has the value of `null` in an API response before this PR will not be contained in the comparable API response after this PR.

This PR resolves the issue brought up in https://github.com/datalad/datalad-registry/pull/184#discussion_r1221783199.

Changes in this PR have been applied to the running instance of datalad-registry on Typhon