### PR TITLE
override `_generate_next_value_` in `StrEnum` and use it in the subclasses of `StrEnum` by calling `auto()`

### DIFF
--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import auto
 from pathlib import Path
 from typing import Optional, Union
 from uuid import UUID
@@ -33,8 +34,8 @@ class OrderDir(StrEnum):
     Enum for representing the order directions
     """
 
-    asc = "asc"
-    desc = "desc"
+    asc = auto()
+    desc = auto()
 
 
 class OrderKey(StrEnum):
@@ -42,12 +43,12 @@ class OrderKey(StrEnum):
     Enum for representing the ordering keys
     """
 
-    url = "url"
-    annex_key_count = "annex_key_count"
-    annexed_files_in_wt_count = "annexed_files_in_wt_count"
-    annexed_files_in_wt_size = "annexed_files_in_wt_size"
-    last_update = "last_update"
-    git_objects_kb = "git_objects_kb"
+    url = auto()
+    annex_key_count = auto()
+    annexed_files_in_wt_count = auto()
+    annexed_files_in_wt_size = auto()
+    last_update = auto()
+    git_objects_kb = auto()
 
 
 class MetadataReturnOption(StrEnum):
@@ -55,8 +56,8 @@ class MetadataReturnOption(StrEnum):
     Enum for representing the metadata return options
     """
 
-    reference = "reference"
-    content = "content"
+    reference = auto()
+    content = auto()
 
 
 class PathParams(BaseModel):

--- a/datalad_registry/tasks.py
+++ b/datalad_registry/tasks.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from enum import auto
 import errno
 import json
 import logging
@@ -36,9 +37,9 @@ InfoType = Dict[str, Union[str, float, datetime]]
 
 
 class ExtractMetaStatus(StrEnum):
-    SUCCEEDED = "succeeded"
-    ABORTED = "aborted"
-    SKIPPED = "skipped"
+    SUCCEEDED = auto()
+    ABORTED = auto()
+    SKIPPED = auto()
 
 
 def _update_dataset_url_info(dataset_url: URL, ds: Dataset) -> None:

--- a/datalad_registry/utils/misc.py
+++ b/datalad_registry/utils/misc.py
@@ -12,7 +12,9 @@ class StrEnum(str, Enum):
     A variation of Enum that is also a subclass of str, akin to IntEnum
     """
 
-    pass
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):  # noqa: U100 (unused)
+        return name
 
 
 def allocate_ds_path() -> Path:

--- a/tools/populate.py
+++ b/tools/populate.py
@@ -4,6 +4,7 @@
 # Note: Currently, this script can only populate the datalad-registry instance with
 #       active datasets on GitHub listed in datalad-usage-dashboard.
 
+from enum import auto
 from typing import Optional
 
 import click
@@ -23,8 +24,8 @@ class Status(StrEnum):
     Enum for representing the status of repo
     """
 
-    active = "active"
-    gone = "gone"
+    active = auto()
+    gone = auto()
 
 
 class Repo(BaseModel):


### PR DESCRIPTION
This PR closes #189.

This is PR is based on #190, so merge master into this PR's branch after #190 is merged into master to get the relevant commits of this PR.

Changes in this PR have been applied to the running instance of datalad-registry on Typhon