### PR TITLE
Debug `test_get_origin_branches()`

### DIFF
--- a/datalad_registry/tests/test_utils/test_datalad_tls.py
+++ b/datalad_registry/tests/test_utils/test_datalad_tls.py
@@ -156,11 +156,16 @@ def test_get_origin_branches(ds_name, request, tmp_path):
 
     origin_branches = get_origin_branches(ds_clone)
 
-    assert origin_branches == [
-        {
-            "name": branch_name,
-            "hexsha": ds.repo.get_hexsha(branch_name),
-            "last_commit_dt": ds.repo.call_git(["log", "-1", "--format=%aI"]).strip(),
+    branch_names = set(ds.repo.get_branches())
+
+    assert set(b["name"] for b in origin_branches) == branch_names
+
+    for b in origin_branches:
+        b_name = b["name"]
+        assert b == {
+            "name": b_name,
+            "hexsha": ds.repo.get_hexsha(b_name),
+            "last_commit_dt": ds.repo.call_git(
+                ["log", "-1", "--format=%aI", b_name]
+            ).strip(),
         }
-        for branch_name in ds.repo.get_branches()
-    ]


### PR DESCRIPTION
This PR removes the bug in this test that causes intermittent failures mostly due to the failure to get log of the referenced branch instead of the log of `HEAD`. Additionally, it makes this test independent of the order of the branches returned by git.