### PR TITLE
Feature: Add Celery monitoring service

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,6 +49,33 @@ services:
       timeout: 3s
       retries: 10
 
+  # Monitor for Celery service
+  monitor:
+    build: .
+    depends_on:
+      broker:
+        condition: service_healthy
+      worker:
+        condition: service_healthy
+    environment:
+      <<: *env
+      FLOWER_BROKER_API: "http://user:$RABBITMQ_DEFAULT_PASS@broker:15672/api/"
+      FLOWER_PERSISTENT: "True"
+      FLOWER_DB: "/app/instance/monitor/flower"
+      FLOWER_STATE_SAVE_INTERVAL: "1000"  # In milliseconds
+      FLOWER_ENABLE_EVENTS: "True"
+      FLOWER_BASIC_AUTH: "$FLOWER_BASIC_AUTH"
+    ports:
+      - "127.0.0.1:5555:5555"
+    command: [ "celery", "--app", "datalad_registry.runcelery.celery", "flower" ]
+    volumes:
+      - ${DL_REGISTRY_INSTANCE_PATH}/monitor:/app/instance/monitor
+    healthcheck:
+      test: RESPONSE=$$(curl -s http://localhost:5555/healthcheck); if [ "$$RESPONSE" = "OK" ]; then exit 0; else exit 1; fi
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
 # TODO: Currently, there is no job to be scheduled.
 #   Disable this to make debugging easier.
 #   Once there is a job to be scheduled, we can uncomment this to enable the scheduler

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ Flask-Migrate==4.0.4
 yarl==1.9.2
 datalad-catalog==0.2.1
 datalad_neuroimaging==0.3.3
+flower==2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     yarl ~= 1.0
     datalad-catalog ~= 0.2.1
     datalad_neuroimaging ~= 0.3.0
+    flower ~= 2.0
 
 packages = find:
 


### PR DESCRIPTION
This PR adds [Flower](https://flower.readthedocs.io/en/latest/) as a service to monitor the Celery cluster. The service is a web app available at port 5555.

The Flower service is set up to run in persistent mode and information about workers and tasks will be saved to the disk periodically.

The changes of this PR will be applied to the running instance of Datalad-registry at Typhon together with the solution for #112. Once that application happens, we should consider closing #133 for the changes in the PR should satisfy the goal of #133.
