### PR TITLE
Set monitor service to use relative time

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -77,7 +77,6 @@ services:
       FLOWER_PERSISTENT: "True"
       FLOWER_DB: "/app/instance/monitor/flower"
       FLOWER_STATE_SAVE_INTERVAL: "1000"  # In milliseconds
-      FLOWER_ENABLE_EVENTS: "True"
       FLOWER_NATURAL_TIME: "True"
       FLOWER_BASIC_AUTH: "$FLOWER_BASIC_AUTH"
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -78,6 +78,7 @@ services:
       FLOWER_DB: "/app/instance/monitor/flower"
       FLOWER_STATE_SAVE_INTERVAL: "1000"  # In milliseconds
       FLOWER_ENABLE_EVENTS: "True"
+      FLOWER_NATURAL_TIME: "True"
       FLOWER_BASIC_AUTH: "$FLOWER_BASIC_AUTH"
     ports:
       - "127.0.0.1:5555:5555"


### PR DESCRIPTION
This PR sets the monitor service, Flower, to use relative time to display tasks info. With this setting, timestamps will be shown as relative time, relative to the page refresh time, such as “2 minutes ago” or “1 hour ago”. This setting will allow user to easily identify recently executed tasks.

Additionally, this PR also remove the setting of the `FLOWER_ENABLE_EVENTS` environment variable for it is not necessary since the default for this setting is our intended value.