### PR TITLE
Exclude tests to be copied to the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@
 **/.DS_Store
 **/*.pyc
 **/__pycache__
+**/tests


### PR DESCRIPTION
This PR further improves the build speed of the Docker image by excluding tests to be copied to the image.