### PR TITLE
Minor: Tell docker to ignore `__pycache__` directories before telling it to ignore the `.pyc` files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,6 @@
 **/*~
 **/*.log
 **/.DS_Store
-**/*.pyc
 **/__pycache__
+**/*.pyc
 **/tests


### PR DESCRIPTION
This will possibly help Docker CLI speed up the determination of the content of the context.