### PR TITLE
Adjust Healthcheck for Podman and other improvements

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -117,7 +117,7 @@ services:
     volumes:
       - ${BROKER_PATH_AT_HOST}/home:/var/lib/rabbitmq
     healthcheck: # https://www.rabbitmq.com/monitoring.html#health-checks
-      test: [ "CMD", "rabbitmq-diagnostics", "-q", "ping" ]
+      test: rabbitmq-diagnostics ping
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -74,7 +74,7 @@ services:
     volumes:
       - ${MONITOR_PATH_AT_HOST}/data:/data
     healthcheck:
-      test: RESPONSE=$$(curl -s http://localhost:5555/healthcheck); echo $$RESPONSE; if [ $$RESPONSE = OK ]; then exit 0; else exit 1; fi
+      test: RESPONSE=$$(curl -s http://localhost:5555/healthcheck); echo $$RESPONSE; if [ "$$RESPONSE" = "OK" ]; then exit 0; else exit 1; fi
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,7 +45,7 @@ services:
     environment:
       <<: *env
     healthcheck:
-      test: celery -A datalad_registry.make_celery:celery_app status --timeout 1 --json | grep -q pong
+      test: celery -A datalad_registry.make_celery:celery_app status --timeout 1 --json | grep pong
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -74,10 +74,7 @@ services:
     volumes:
       - ${MONITOR_PATH_AT_HOST}/data:/data
     healthcheck:
-      test: [
-        "CMD", "bash", "-c",
-        "RESPONSE=$$(curl -s http://localhost:5555/healthcheck); if [ \"$$RESPONSE\" = \"OK\" ]; then exit 0; else exit 1; fi"
-      ]
+      test: RESPONSE=$$(curl -s http://localhost:5555/healthcheck); if [ $$RESPONSE = OK ]; then exit 0; else exit 1; fi
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -148,7 +148,7 @@ services:
     volumes:
       - ${DB_PATH_AT_HOST}/data:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}", "-q" ]
+      test: pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} -q
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -74,7 +74,7 @@ services:
     volumes:
       - ${MONITOR_PATH_AT_HOST}/data:/data
     healthcheck:
-      test: RESPONSE=$$(curl -s http://localhost:5555/healthcheck); if [ $$RESPONSE = OK ]; then exit 0; else exit 1; fi
+      test: RESPONSE=$$(curl -s http://localhost:5555/healthcheck); echo $$RESPONSE; if [ $$RESPONSE = OK ]; then exit 0; else exit 1; fi
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,6 +52,8 @@ services:
       interval: 30s
       timeout: 30s
       retries: 3
+      start_period: 3m
+      start_interval: 5s
 
   # Monitor for Celery service
   monitor:
@@ -82,6 +84,8 @@ services:
       interval: 30s
       timeout: 30s
       retries: 3
+      start_period: 3m
+      start_interval: 5s
 
   # TODO: Currently, there is no job to be scheduled.
   #   Disable this to make debugging easier.
@@ -123,6 +127,8 @@ services:
       interval: 30s
       timeout: 30s
       retries: 3
+      start_period: 1m
+      start_interval: 5s
 
   # Result backend for Celery
   backend:
@@ -152,3 +158,5 @@ services:
       interval: 30s
       timeout: 30s
       retries: 3
+      start_period: 1m
+      start_interval: 5s

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -148,7 +148,7 @@ services:
     volumes:
       - ${DB_PATH_AT_HOST}/data:/var/lib/postgresql/data
     healthcheck:
-      test: pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} -q
+      test: pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,10 +45,7 @@ services:
     environment:
       <<: *env
     healthcheck:
-      test: [
-        "CMD", "bash", "-c",
-        "celery -A datalad_registry.make_celery:celery_app status --timeout 1 --json | grep -q pong"
-      ]
+      test: celery -A datalad_registry.make_celery:celery_app status --timeout 1 --json | grep -q pong
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
Podman currently doesn't support health check tests in list form. This PR expresses all health check tests in shell script form. Additionally, this PR add the following feature to health checks.

1. Specifies start period and start interval for health checks
2. Un-silence all health checks so that their output can be captured and logged.