### PR TITLE
Remove `start_interval` in `healthcheck`

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,7 +50,6 @@ services:
       timeout: 30s
       retries: 3
       start_period: 3m
-      start_interval: 5s
 
   # Monitor for Celery service
   monitor:
@@ -79,7 +78,6 @@ services:
       timeout: 30s
       retries: 3
       start_period: 3m
-      start_interval: 5s
 
   # TODO: Currently, there is no job to be scheduled.
   #   Disable this to make debugging easier.
@@ -122,7 +120,6 @@ services:
       timeout: 30s
       retries: 3
       start_period: 1m
-      start_interval: 5s
 
   # Result backend for Celery
   backend:
@@ -153,4 +150,3 @@ services:
       timeout: 30s
       retries: 3
       start_period: 1m
-      start_interval: 5s


### PR DESCRIPTION
It is not yet supported in docker compose