### PR TITLE
Place limits on the repeated use of individual worker processes

### DIFF
--- a/datalad_registry/conf.py
+++ b/datalad_registry/conf.py
@@ -42,6 +42,8 @@ class BaseConfig(OperationConfig):
             broker_url=self.CELERY_BROKER_URL,
             result_backend=self.CELERY_RESULT_BACKEND,
             task_ignore_result=True,
+            worker_max_tasks_per_child=1000,
+            worker_max_memory_per_child=1000 * 500,  # 500 MB
         )
 
     # =============================================

--- a/datalad_registry/tests/test__init__.py
+++ b/datalad_registry/tests/test__init__.py
@@ -74,6 +74,8 @@ class TestCreateApp:
             "broker_url": broker_url,
             "result_backend": result_backend,
             "task_ignore_result": True,
+            "worker_max_tasks_per_child": 1000,
+            "worker_max_memory_per_child": 500_000,  # 500 MB
         }
         assert (
             flask_app.config["SQLALCHEMY_DATABASE_URI"]

--- a/datalad_registry/tests/test_conf.py
+++ b/datalad_registry/tests/test_conf.py
@@ -100,6 +100,8 @@ class TestBaseConfig:
             broker_url=expected_broker_url,
             result_backend=result_backend,
             task_ignore_result=True,
+            worker_max_tasks_per_child=1000,
+            worker_max_memory_per_child=500_000,  # 500 MB
         )
 
 


### PR DESCRIPTION
Place limits on the repeated use of individual worker processes. If a worker process has been used more than 1000 times or has used more than 500MB resident memory, it will be replaced by a new worker process. These configurations are put in place to control affect of possible memory leaks.

For more information, please check out the following documentations.

1. https://docs.celeryq.dev/en/stable/userguide/workers.html#max-tasks-per-child-setting
2. https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-worker_max_tasks_per_child