### PR TITLE
Update Celery and Flower dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ Flask-Migrate==4.0.4
 yarl==1.9.2
 datalad-catalog==0.2.1
 datalad_neuroimaging==0.3.3
-flower==2.0.0
+flower==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-celery[redis]==5.2.7
+celery[redis]==5.3.1
 click==8.1.3
 datalad==0.18.0
 datalad-metalad==0.4.12


### PR DESCRIPTION
This PR updates Celery and Flower to the latest versions, 5.3.1 and 2.0.1, respectively.