### PR TITLE
Additional type support for Celery task arguments

### DIFF
--- a/datalad_registry/__init__.py
+++ b/datalad_registry/__init__.py
@@ -11,7 +11,7 @@ from werkzeug.exceptions import HTTPException
 from . import overview, root
 from .conf import compile_config_from_env
 from .models import db, init_db_command, migrate
-from .utils.pydantic_json import pydantic_model_dumps, pydantic_model_loads
+from .utils.pydantic_json import pydantic_dumps, pydantic_model_loads
 
 if sys.version_info[:2] < (3, 8):
     from importlib_metadata import version
@@ -120,7 +120,7 @@ def celery_init_app(flask_app: Flask) -> Celery:
     # Pydantic models as a serializer
     register(
         "pydantic_json",
-        pydantic_model_dumps,
+        pydantic_dumps,
         pydantic_model_loads,
         content_type="application/x-pydantic-json",
         content_encoding="utf-8",

--- a/datalad_registry/__init__.py
+++ b/datalad_registry/__init__.py
@@ -11,7 +11,7 @@ from werkzeug.exceptions import HTTPException
 from . import overview, root
 from .conf import compile_config_from_env
 from .models import db, init_db_command, migrate
-from .utils.pydantic_json import pydantic_dumps, pydantic_model_loads
+from .utils.pydantic_json import pydantic_dumps, pydantic_loads
 
 if sys.version_info[:2] < (3, 8):
     from importlib_metadata import version
@@ -121,7 +121,7 @@ def celery_init_app(flask_app: Flask) -> Celery:
     register(
         "pydantic_json",
         pydantic_dumps,
-        pydantic_model_loads,
+        pydantic_loads,
         content_type="application/x-pydantic-json",
         content_encoding="utf-8",
     )

--- a/datalad_registry/__init__.py
+++ b/datalad_registry/__init__.py
@@ -117,7 +117,7 @@ def celery_init_app(flask_app: Flask) -> Celery:
     celery_app.config_from_object(flask_app.config["CELERY"])
 
     # Register JSON encoding and decoding functions with additional support of
-    # Pydantic models as a serializer
+    # Pydantic models and other supported types by Pydantic for JSON serialization
     register(
         "pydantic_json",
         pydantic_dumps,
@@ -126,7 +126,7 @@ def celery_init_app(flask_app: Flask) -> Celery:
         content_encoding="utf-8",
     )
 
-    # Set the Celery app to use the JSON serializer with support for Pydantic models
+    # Set the Celery app to use the JSON serializer registered above
     celery_app.conf.update(
         accept_content=["pydantic_json"],
         task_serializer="pydantic_json",

--- a/datalad_registry/tests/test_utils/test_pydantic_json.py
+++ b/datalad_registry/tests/test_utils/test_pydantic_json.py
@@ -1,5 +1,9 @@
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
 from typing import List, Optional
+from uuid import UUID
 
 from pydantic import BaseModel, validate_arguments
 import pytest
@@ -35,6 +39,64 @@ n = None
 )
 def test_basic_types(test_input, expected_output):
     assert pydantic_model_loads(pydantic_model_dumps(test_input)) == expected_output
+
+
+# ===== Test for supported complex standard types ============================
+@validate_arguments
+def return_datetime(dt: datetime) -> datetime:
+    return dt
+
+
+@validate_arguments
+def return_decimal(dec: Decimal) -> Decimal:
+    return dec
+
+
+@validate_arguments
+def return_path(pth: Path) -> Path:
+    return pth
+
+
+@validate_arguments
+def return_uuid(uid: UUID) -> UUID:
+    return uid
+
+
+@dataclass
+class FooData:
+    a: int
+    b: str
+
+
+@validate_arguments
+def return_foo_data(fd: FooData) -> FooData:
+    return fd
+
+
+@pytest.mark.parametrize(
+    "io_put, process_func",
+    [
+        (
+            datetime(
+                year=1999,
+                month=12,
+                day=13,
+                hour=11,
+                minute=30,
+                second=44,
+                microsecond=14983,
+                tzinfo=timezone.utc,
+            ),
+            return_datetime,
+        ),
+        (Decimal("499.543"), return_decimal),
+        (Path("/the/middle/path"), return_path),
+        (UUID("c55f3251-54eb-4961-be58-0c2d2d24dc24"), return_uuid),
+        (FooData(a=1, b="foo"), return_foo_data),
+    ],
+)
+def test_supported_complex_standard_types(io_put, process_func):
+    assert process_func(pydantic_model_loads(pydantic_model_dumps(io_put))) == io_put
 
 
 # ==== Test for handling pydantic model types =================================
@@ -101,12 +163,8 @@ def test_pydantic_model_types(test_input, expected_output, process_func):
 
 
 # ==== Test for handling unsupported types ====================================
-@dataclass
-class DataclassUser:
-    id: int
-    name = "Jane Doe"
 
 
 def test_unsupported_types():
     with pytest.raises(TypeError):
-        pydantic_model_dumps(DataclassUser(id=1))
+        pydantic_model_dumps(return_datetime)

--- a/datalad_registry/tests/test_utils/test_pydantic_json.py
+++ b/datalad_registry/tests/test_utils/test_pydantic_json.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from pydantic import BaseModel, validate_arguments
 import pytest
 
-from datalad_registry.utils.pydantic_json import pydantic_dumps, pydantic_model_loads
+from datalad_registry.utils.pydantic_json import pydantic_dumps, pydantic_loads
 
 # ==== Test for handling basic types =======================================
 d = {"a": 1, "b": 2}
@@ -35,7 +35,7 @@ n = None
     ],
 )
 def test_basic_types(test_input, expected_output):
-    assert pydantic_model_loads(pydantic_dumps(test_input)) == expected_output
+    assert pydantic_loads(pydantic_dumps(test_input)) == expected_output
 
 
 # ===== Test for supported complex standard types ============================
@@ -93,7 +93,7 @@ def return_foo_data(fd: FooData) -> FooData:
     ],
 )
 def test_supported_complex_standard_types(io_put, process_func):
-    assert process_func(pydantic_model_loads(pydantic_dumps(io_put))) == io_put
+    assert process_func(pydantic_loads(pydantic_dumps(io_put))) == io_put
 
 
 # ==== Test for handling pydantic model types =================================
@@ -153,10 +153,7 @@ def return_list_of_spams(spam_list: List[Spam]) -> List[Spam]:
     ],
 )
 def test_pydantic_model_types(test_input, expected_output, process_func):
-    assert (
-        process_func(pydantic_model_loads(pydantic_dumps(test_input)))
-        == expected_output
-    )
+    assert process_func(pydantic_loads(pydantic_dumps(test_input))) == expected_output
 
 
 # ==== Test for handling unsupported types ====================================

--- a/datalad_registry/tests/test_utils/test_pydantic_json.py
+++ b/datalad_registry/tests/test_utils/test_pydantic_json.py
@@ -8,10 +8,7 @@ from uuid import UUID
 from pydantic import BaseModel, validate_arguments
 import pytest
 
-from datalad_registry.utils.pydantic_json import (
-    pydantic_model_dumps,
-    pydantic_model_loads,
-)
+from datalad_registry.utils.pydantic_json import pydantic_dumps, pydantic_model_loads
 
 # ==== Test for handling basic types =======================================
 d = {"a": 1, "b": 2}
@@ -38,7 +35,7 @@ n = None
     ],
 )
 def test_basic_types(test_input, expected_output):
-    assert pydantic_model_loads(pydantic_model_dumps(test_input)) == expected_output
+    assert pydantic_model_loads(pydantic_dumps(test_input)) == expected_output
 
 
 # ===== Test for supported complex standard types ============================
@@ -96,7 +93,7 @@ def return_foo_data(fd: FooData) -> FooData:
     ],
 )
 def test_supported_complex_standard_types(io_put, process_func):
-    assert process_func(pydantic_model_loads(pydantic_model_dumps(io_put))) == io_put
+    assert process_func(pydantic_model_loads(pydantic_dumps(io_put))) == io_put
 
 
 # ==== Test for handling pydantic model types =================================
@@ -157,7 +154,7 @@ def return_list_of_spams(spam_list: List[Spam]) -> List[Spam]:
 )
 def test_pydantic_model_types(test_input, expected_output, process_func):
     assert (
-        process_func(pydantic_model_loads(pydantic_model_dumps(test_input)))
+        process_func(pydantic_model_loads(pydantic_dumps(test_input)))
         == expected_output
     )
 
@@ -167,4 +164,4 @@ def test_pydantic_model_types(test_input, expected_output, process_func):
 
 def test_unsupported_types():
     with pytest.raises(TypeError):
-        pydantic_model_dumps(return_datetime)
+        pydantic_dumps(return_datetime)

--- a/datalad_registry/tests/test_utils/test_pydantic_json.py
+++ b/datalad_registry/tests/test_utils/test_pydantic_json.py
@@ -9,7 +9,7 @@ from datalad_registry.utils.pydantic_json import (
     pydantic_model_loads,
 )
 
-# ==== Test for handling standard types =======================================
+# ==== Test for handling basic types =======================================
 d = {"a": 1, "b": 2}
 lst = [1, 2, 3]
 t = (1, 2, 3)
@@ -33,7 +33,7 @@ n = None
         (n, n),
     ],
 )
-def test_standard_types(test_input, expected_output):
+def test_basic_types(test_input, expected_output):
     assert pydantic_model_loads(pydantic_model_dumps(test_input)) == expected_output
 
 

--- a/datalad_registry/utils/pydantic_json.py
+++ b/datalad_registry/utils/pydantic_json.py
@@ -3,19 +3,12 @@
 # This serializer should be used together with the @validate_arguments decorator
 # from Pydantic to allow Pydantic models to be passed to Celery tasks as arguments.
 
-from kombu.utils.json import JSONEncoder, dumps, loads
-from pydantic import BaseModel
-
-
-class PydanticModelJSONEncoder(JSONEncoder):
-    def default(self, obj, *args, **kwargs):
-        if isinstance(obj, BaseModel):
-            return obj.dict()
-        return JSONEncoder.default(self, obj, *args, **kwargs)
+from kombu.utils.json import dumps, loads
+from pydantic.json import pydantic_encoder
 
 
 def pydantic_model_dumps(obj):
-    return dumps(obj, cls=PydanticModelJSONEncoder)
+    return dumps(obj, default=pydantic_encoder)
 
 
 pydantic_model_loads = loads

--- a/datalad_registry/utils/pydantic_json.py
+++ b/datalad_registry/utils/pydantic_json.py
@@ -11,4 +11,4 @@ def pydantic_dumps(obj):
     return dumps(obj, default=pydantic_encoder)
 
 
-pydantic_model_loads = loads
+pydantic_loads = loads

--- a/datalad_registry/utils/pydantic_json.py
+++ b/datalad_registry/utils/pydantic_json.py
@@ -7,7 +7,7 @@ from kombu.utils.json import dumps, loads
 from pydantic.json import pydantic_encoder
 
 
-def pydantic_model_dumps(obj):
+def pydantic_dumps(obj):
     return dumps(obj, default=pydantic_encoder)
 
 

--- a/datalad_registry/utils/pydantic_json.py
+++ b/datalad_registry/utils/pydantic_json.py
@@ -1,7 +1,10 @@
-# This module extends the JSON serializer used by Celery
-# by adding support for Pydantic models.
-# This serializer should be used together with the @validate_arguments decorator
-# from Pydantic to allow Pydantic models to be passed to Celery tasks as arguments.
+# This module extends the default JSON serializer used by Celery by adding JSON
+# serialization support for types supported by Pydantic for JSON serialization.
+# These are the types that are allowed as a type for a field in a Pydantic model.
+# They include `datetime.datetime`, `decimal.Decimal`, `pathlib.Path`, `uuid.UUID`,
+# Pydantic models themselves, and more.
+# This serializer should be used in conjunction with the @validate_arguments decorator
+# from Pydantic to allow the additional types to be passed to Celery tasks as arguments.
 
 from kombu.utils.json import dumps, loads
 from pydantic.json import pydantic_encoder


### PR DESCRIPTION
This PR adds support for additional types as Celery task arguments.

This PR allows arguments of Celery tasks to be of any type that is allowed as a field type of a Pydantic model. Thus, an argument of a Celery task can be the type of `datetime.datetime`, `decimal.Decimal`, `pathlib.Path`, `uuid.UUID`, Pydantic models themselves, and more. 