### PR TITLE
Minor improvements to search/filter of dataset URLs

### DIFF
--- a/datalad_registry/overview.py
+++ b/datalad_registry/overview.py
@@ -4,7 +4,7 @@
 import logging
 
 from flask import Blueprint, render_template, request
-from sqlalchemy import nullslast, or_, String
+from sqlalchemy import Text, nullslast, or_
 
 from datalad_registry.models import RepoUrl, URLMetadata, db
 
@@ -53,7 +53,9 @@ def overview():  # No type hints due to mypy#7187.
                         # It seems to serialize nested fields
                         # URLMetadata.extracted_metadata['entities'].as_string().contains(filter)
                         # search the entire record!
-                        URLMetadata.extracted_metadata.cast(String).contains(filter),
+                        URLMetadata.extracted_metadata.cast(Text).contains(
+                            filter, autoescape=True
+                        ),
                     )
                 ),
             )


### PR DESCRIPTION
This PR is a follow up to PR #241.

Some minor improvements are added to the filtering/searching of dataset URLs as follow

1. Cast `extracted_metadata` to `Text`
    -  `Text` type documents the content is of variable length
2. `Text` and enable `autoescape`
   -   Enabling `autoescape` ensures the value to search for is interpreted as a string literal

