### PR TITLE
Add basic DANDI metadata "extraction"

### DIFF
--- a/datalad_registry/conf.py
+++ b/datalad_registry/conf.py
@@ -29,6 +29,9 @@ class BaseConfig(OperationConfig):
         "metalad_studyminimeta",
         "datacite_gin",
         "bids_dataset",
+        # dandi: is ATM just native loading of dandiset.yaml and the .dandi/assets.json dumps
+        "dandi:dandiset",
+        "dandi:assets",
     ]
 
     # === worker, Celery, related configuration  ===


### PR DESCRIPTION
Not even really extraction since we will just load stored in DataLad dandisets .yaml (and later .json files for assets).

TODO:

- [ ] replace prototyped code with proper python (asset level metadata -- postpone for now)
- [ ] deploy and see what happens -- in principle we should also be able to search through dandisets