### PR TITLE
Use Pydantic's `BaseModel`'s interface for JSON serialization instead in building of the JSON error responses

### DIFF
--- a/datalad_registry/__init__.py
+++ b/datalad_registry/__init__.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 import sys
 
@@ -78,11 +77,9 @@ def create_app() -> Flask:
             # start with the correct headers and status code from the error
             response = e.get_response()
             # replace the body with JSON
-            response.data = json.dumps(
-                HTTPExceptionResp(
-                    code=e.code, name=e.name, description=e.description
-                ).dict()
-            )
+            response.data = HTTPExceptionResp(
+                code=e.code, name=e.name, description=e.description
+            ).json()
             response.content_type = "application/json"
             return response
         else:


### PR DESCRIPTION
This PR includes a minor refactoring of the building of the JSON response in case of an internal `HTTPException`. The changes uses Pydantic's `BaseModel`'s interface for JSON serialization instead. This make the involved code more direct and consistent with rest of the project.