### PR TITLE
Fix the Python env to specs in `requirements.txt` and restrict Flask version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
+        pip install -r requirements.txt
         pip install wheel
         pip install mypy types-requests
         pip install .[tests]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     click
     datalad >= 0.18.0
     datalad-metalad >= 0.4
+    Flask ~= 2.3
     flask-openapi3 ~= 2.3
     Flask-SQLAlchemy
     importlib-metadata; python_version < "3.8"


### PR DESCRIPTION
This PR does two things:

1. Fix the Python env to specs in `requirements.txt`. This will allow finer control in the versions of dependent packages got installed in the workflow environment.
2. Restrict Flask to version below 3.0. The latest version of Flask, 3.0, doesn't work with the existing code. Let's restrict the version of Flask to be below 3.0 for now and update the code base to support Flask 3.0+ in another occasion.