### PR TITLE
Restrict Flask to version below 3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     click
     datalad >= 0.18.0
     datalad-metalad >= 0.4
+    Flask ~= 2.3
     flask-openapi3 ~= 2.3
     Flask-SQLAlchemy
     importlib-metadata; python_version < "3.8"


### PR DESCRIPTION
The latest version of Flask, 3.0, doesn't work with the existing code. Let's restrict the version of Flask to be below 3.0 for now and update the code base to support Flask 3.0+ in another occasion.