### PR TITLE
Clear instance path in flask app fixture

### DIFF
--- a/datalad_registry/tests/conftest.py
+++ b/datalad_registry/tests/conftest.py
@@ -55,10 +55,12 @@ def flask_app(_flask_app):
         db.drop_all()
         db.create_all()
 
-    # Reset the base local cache for datasets
+    # Clear the instance folder of the Flask app and the base local cache for datasets
+    instance_path = Path(_flask_app.instance_path)
     cache_path = _flask_app.config["DATALAD_REGISTRY_DATASET_CACHE"]
-    rm_ds_tree(cache_path)
-    cache_path.mkdir()
+    for p in [instance_path, cache_path]:
+        rm_ds_tree(p)
+        p.mkdir()
 
     celery_app: Celery = _flask_app.extensions["celery"]
 


### PR DESCRIPTION
This PR ensures that the flask app fixture used in tests provides a clean instance folder for the Flask app initially.