### PR TITLE
Add `participants.tsv` as a required file for the `bids_dataset` metadata extractor

### DIFF
--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -109,7 +109,7 @@ def _update_dataset_url_info(dataset_url: RepoUrl, ds: Dataset) -> None:
 _EXTRACTOR_REQUIRED_FILES = {
     "metalad_studyminimeta": [".studyminimeta.yaml"],
     "datacite_gin": ["datacite.yml"],
-    "bids_dataset": ["dataset_description.json"],
+    "bids_dataset": ["dataset_description.json", "participants.tsv"],
 }
 
 


### PR DESCRIPTION
According to the error depicted below, `participants.tsv` is a required file for the `bids_dataset` metadata extractor. This PR adds `participants.tsv` as a required file for  the `bids_dataset` metadata extractor, so that the `bids_dataset` metadata extraction terminates gracefully when dealing with a dataset that doesn't have the `participants.tsv` file.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/celery/app/trace.py", line 477, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/app/datalad_registry/__init__.py", line 111, in __call__
    return self.run(*args, **kwargs)
  File "pydantic/decorator.py", line 40, in pydantic.decorator.validate_arguments.validate.wrapper_function
  File "pydantic/decorator.py", line 134, in pydantic.decorator.ValidatedFunction.call
  File "pydantic/decorator.py", line 206, in pydantic.decorator.ValidatedFunction.execute
  File "/app/datalad_registry/tasks/__init__.py", line 224, in extract_ds_meta
    dl.meta_extract(
  File "/usr/local/lib/python3.9/dist-packages/datalad/interface/base.py", line 773, in eval_func
    return return_func(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/datalad/interface/base.py", line 763, in return_func
    results = list(results)
  File "/usr/local/lib/python3.9/dist-packages/datalad/interface/base.py", line 873, in _execute_command_
    for r in _process_results(
  File "/usr/local/lib/python3.9/dist-packages/datalad/interface/utils.py", line 319, in _process_results
    for res in results:
  File "/usr/local/lib/python3.9/dist-packages/datalad_metalad/extract.py", line 317, in __call__
    yield from do_dataset_extraction(extraction_arguments)
  File "/usr/local/lib/python3.9/dist-packages/datalad_metalad/extract.py", line 379, in do_dataset_extraction
    yield from perform_dataset_metadata_extraction(ep, extractor)
  File "/usr/local/lib/python3.9/dist-packages/datalad_metalad/extract.py", line 461, in perform_dataset_metadata_extraction
    if extractor.get_required_content() is False:
  File "/usr/local/lib/python3.9/dist-packages/datalad_neuroimaging/extractors/bids_dataset.py", line 150, in get_required_content
    bids_dir = _find_bids_root(self.dataset.path)
  File "/usr/local/lib/python3.9/dist-packages/datalad_neuroimaging/extractors/bids_dataset.py", line 308, in _find_bids_root
    raise FileNotFoundError(msg)
FileNotFoundError: The file 'participants.tsv' should be part of the BIDS dataset in order for the 'bids_dataset' extractor to function correctly
```