### PR TITLE
Simplify `validate_url_is_processed`

### DIFF
--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -27,7 +27,7 @@ from datalad_registry.utils.datalad_tls import (
     get_wt_annexed_file_info,
 )
 
-from .utils import allocate_ds_path, update_ds_clone, validate_url_is_processed
+from .utils import allocate_ds_path, update_ds_clone
 from .utils.builtin_meta_extractors import EXTRACTOR_MAP as BUILTIN_EXTRACTOR_MAP
 from .utils.builtin_meta_extractors import InvalidRequiredFileError, dlreg_meta_extract
 
@@ -155,13 +155,13 @@ def extract_ds_meta(ds_url_id: StrictInt, extractor: StrictStr) -> ExtractMetaSt
                 supposed ID of a RepoUrl that doesn't identify any RepoUrl in
                 the database at the time of the execution of this task because
                 the RepoUrl has been deleted from the database.)
-    :raise: ValueError if the RepoUrl of the specified ID does not exist or has not
-                been processed yet.
+    :raise: ValueError if the RepoUrl of the specified ID has not been processed yet.
     :raise: RuntimeError if the extractor returns an execution status other than "ok"
 
     """
 
     # Get the RepoUrl from the database by ID with a read/share lock
+    # noinspection DuplicatedCode
     url = (
         db.session.execute(
             select(RepoUrl).filter_by(id=ds_url_id).with_for_update(read=True)
@@ -174,7 +174,11 @@ def extract_ds_meta(ds_url_id: StrictInt, extractor: StrictStr) -> ExtractMetaSt
         # === there is no RepoUrl in the database with the specified ID ===
         return ExtractMetaStatus.NO_RECORD
 
-    validate_url_is_processed(url)
+    # Validate that the RepoUrl has been processed
+    if not url.processed:
+        raise ValueError(
+            f"RepoUrl {url.url}, of ID: {url.id}, has not been processed yet"
+        )
 
     # Absolute path of the dataset clone in cache
     cache_path_abs = url.cache_path_abs
@@ -510,12 +514,12 @@ def chk_url_to_update(
                    in the database
     :param initial_last_chk_dt: The value of `last_chk_dt` of the `RepoUrl`
                                 when this check was initiated.
-    :raise: ValueError if the RepoUrl of the specified ID does not exist or has not
-            been processed yet.
+    :raise: ValueError if the RepoUrl of the specified ID has not been processed yet.
     """
 
     # Select and lock the RepoUrl identified by the given ID if it is not locked
     # by another transaction
+    # noinspection DuplicatedCode
     url = (
         db.session.execute(
             select(RepoUrl).filter_by(id=url_id).with_for_update(skip_locked=True)
@@ -536,7 +540,11 @@ def chk_url_to_update(
     # locked by the current transaction
     # ===
 
-    validate_url_is_processed(url)
+    # Validate that the RepoUrl has been processed
+    if not url.processed:
+        raise ValueError(
+            f"RepoUrl {url.url}, of ID: {url.id}, has not been processed yet"
+        )
 
     if url.last_chk_dt != initial_last_chk_dt:
         # The RepoUrl has been checked by another process since this check was initiated

--- a/datalad_registry/tasks/utils/__init__.py
+++ b/datalad_registry/tasks/utils/__init__.py
@@ -52,9 +52,6 @@ def validate_url_is_processed(repo_url: RepoUrl) -> None:
     Validate that a given RepoUrl has been marked processed
 
     :raise: ValueError if the given RepoUrl has not been marked processed
-
-    Note: This function is meant to be called inside a Celery task for it requires
-          an active application context of the Flask app
     """
 
     if not repo_url.processed:

--- a/datalad_registry/tasks/utils/__init__.py
+++ b/datalad_registry/tasks/utils/__init__.py
@@ -47,6 +47,22 @@ def allocate_ds_path() -> Path:
             return path
 
 
+def validate_url_is_processed(repo_url: RepoUrl) -> None:
+    """
+    Validate that a given RepoUrl has been marked processed
+
+    :raise: ValueError if the given RepoUrl has not been marked processed
+
+    Note: This function is meant to be called inside a Celery task for it requires
+          an active application context of the Flask app
+    """
+
+    if not repo_url.processed:
+        raise ValueError(
+            f"RepoUrl {repo_url.url}, of ID: {repo_url.id}, has not been processed yet"
+        )
+
+
 def update_ds_clone(repo_url: RepoUrl) -> tuple[Dataset, bool]:
     """
     Update the local clone of the dataset at a given URL
@@ -102,10 +118,7 @@ def update_ds_clone(repo_url: RepoUrl) -> tuple[Dataset, bool]:
             return ds_clone
 
     # Validate that the given RepoUrl has been marked processed
-    if not repo_url.processed:
-        raise ValueError(
-            f"RepoUrl {repo_url.url}, of ID: {repo_url.id}, has not been processed yet"
-        )
+    validate_url_is_processed(repo_url)
 
     base_cache_path: Path = current_app.config["DATALAD_REGISTRY_DATASET_CACHE"]
 


### PR DESCRIPTION
Simplify the helper `validate_url_is_processed()`. It is really better to just check the `processed` without checking the `cache_path` of the URL in the sense that a processed URL always have a cache path and mypy required cache path to be assert to be not None in context.

This PR is based on #262. To get the relevant commits related with this PR, the master branch should be merged into the associated branch of this PR after #262  is merged into the master branch.