### PR TITLE
Specify the version of the annexremote dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+annexremote==1.6.0
 celery[redis]==5.3.1
 click==8.1.3
 datalad==0.19.3


### PR DESCRIPTION
This allows finer control over which version of annexremote is installed in the Python environment.