### PR TITLE
Remove worker service dependency in Docker Compose file

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -56,8 +56,6 @@ services:
     depends_on:
       broker:
         condition: service_healthy
-      worker:
-        condition: service_healthy
     command: [
       "bash", "-c",
       "celery -A datalad_registry.make_celery:celery_app beat -s /data/celerybeat-schedule -l INFO"
@@ -78,8 +76,6 @@ services:
     image: datalad-registry:dev
     depends_on:
       broker:
-        condition: service_healthy
-      worker:
         condition: service_healthy
     environment:
       <<: *env


### PR DESCRIPTION
This PR removes the worker service dependency from the scheduler and monitor services. The startups and shutdowns of the scheduler and monitor services don't really depend on the worker service.
