### PR TITLE
Eliminate shellcheck err in by adding `-r` option

### DIFF
--- a/tools/populate_datasets.datalad.org
+++ b/tools/populate_datasets.datalad.org
@@ -5,7 +5,7 @@ set -eu
 topp="/srv/datasets.datalad.org/www"
 
 ssh falkor.datalad.org find "$topp" -iname .git -type d | sed -e "s,$topp/\(.*\),https://datasets.datalad.org/\1,g" \
-| while read url; do
+| while read -r url; do
 curl -X 'POST' \
   'http://localhost:5000/api/v2/dataset-urls' \
   -H 'accept: application/json' \


### PR DESCRIPTION
This PR eliminate the shellcheck complain about calling `read` without the `-r` option.

We should be able to call `read` with the `-r` option in the use case since URLs can't contain `"\"`.