### PR TITLE
Worker pids limit

### DIFF
--- a/docker-compose.dev.no-worker.yml
+++ b/docker-compose.dev.no-worker.yml
@@ -1,0 +1,130 @@
+services:
+  web:
+    build:
+      dockerfile: dev.Dockerfile
+      ## Old docker-compose asked for context but this was still insufficient
+      ## since it could then "link" the built image here to be used for the worker
+      # context: .
+    image: datalad-registry:dev
+    depends_on:
+      broker:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+    ports:
+      - "5000:5000"
+    environment: &env
+      FLASK_APP: "datalad_registry:create_app"
+
+      DATALAD_REGISTRY_OPERATION_MODE: "${DATALAD_REGISTRY_OPERATION_MODE}"
+      DATALAD_REGISTRY_INSTANCE_PATH: /app/instance
+      DATALAD_REGISTRY_DATASET_CACHE: /data/cache
+
+      CELERY_BROKER_URL: "${CELERY_BROKER_URL}"
+      CELERY_RESULT_BACKEND: "redis://backend:6379"
+
+      # db service access info
+      SQLALCHEMY_DATABASE_URI: "${SQLALCHEMY_DATABASE_URI}"
+    command: [ "bash", "-c", "flask init-db && flask run --host=0.0.0.0" ]
+    volumes:
+      - ${WEB_PATH_AT_HOST}/instance:/app/instance
+
+  scheduler:
+    image: datalad-registry:dev
+    depends_on:
+      broker:
+        condition: service_healthy
+    command: [
+      "bash", "-c",
+      "celery -A datalad_registry.make_celery:celery_app beat -s /data/celerybeat-schedule -l INFO"
+    ]
+    volumes:
+      - ${SCHEDULER_PATH_AT_HOST}/data:/data
+    environment:
+      <<: *env
+    healthcheck:
+      test: celery -A datalad_registry.make_celery:celery_app status --timeout 1 --json | grep pong
+      interval: 30s
+      timeout: 30s
+      retries: 3
+      start_period: 3m
+
+  # Monitor for Celery service
+  monitor:
+    image: datalad-registry:dev
+    depends_on:
+      broker:
+        condition: service_healthy
+    environment:
+      <<: *env
+      FLOWER_BROKER_API: "${FLOWER_BROKER_API}"
+      FLOWER_PERSISTENT: "True"
+      FLOWER_DB: "/data/flower"
+      FLOWER_STATE_SAVE_INTERVAL: "1000"  # In milliseconds
+      FLOWER_NATURAL_TIME: "True"
+      FLOWER_BASIC_AUTH: "$FLOWER_BASIC_AUTH"
+    ports:
+      - "127.0.0.1:5555:5555"
+    command: [ "bash", "-c", "celery -A datalad_registry.make_celery:celery_app flower" ]
+    volumes:
+      - ${MONITOR_PATH_AT_HOST}/data:/data
+    healthcheck:
+      test: RESPONSE=$$(curl -s http://localhost:5555/healthcheck); echo $$RESPONSE; if [ "$$RESPONSE" = "OK" ]; then exit 0; else exit 1; fi
+      interval: 30s
+      timeout: 30s
+      retries: 3
+      start_period: 3m
+
+  broker:
+    image: docker.io/rabbitmq:3-management
+    hostname: dlreg-broker
+    environment:
+      RABBITMQ_DEFAULT_USER: "${RABBITMQ_DEFAULT_USER}"
+      RABBITMQ_DEFAULT_PASS: "${RABBITMQ_DEFAULT_PASS}"
+      RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: "-rabbit consumer_timeout 43200000"  # 12 hours in milliseconds
+    ports:
+      - "127.0.0.1:5672:5672"
+      - "127.0.0.1:15672:15672"
+    userns_mode: "keep-id"  # This has an effect only after podman-compose 1.0.3 possibly
+      # See https://github.com/containers/podman-compose/issues/166
+      # for details.
+      # For podman-compose 1.0.3 or earlier, use
+      # `PODMAN_USERNS=keep-id podman-compose up`
+    volumes:
+      - ${BROKER_PATH_AT_HOST}/home:/var/lib/rabbitmq
+    healthcheck: # https://www.rabbitmq.com/monitoring.html#health-checks
+      test: rabbitmq-diagnostics ping
+      interval: 30s
+      timeout: 30s
+      retries: 3
+      start_period: 1m
+
+  # Result backend for Celery
+  backend:
+    image: docker.io/redis:7
+    ports:
+      - "127.0.0.1:6379:6379"
+
+  db:
+    image: docker.io/postgres:latest
+    environment:
+      POSTGRES_DB: "${POSTGRES_DB}"
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_INITDB_ARGS: --encoding utf8 --locale C
+    ports:
+      - "5432:5432"
+    userns_mode: "keep-id"  # This has an effect only after podman-compose 1.0.3 possibly
+      # See https://github.com/containers/podman-compose/issues/166
+      # for details.
+      # For podman-compose 1.0.3 or earlier, use
+      # `PODMAN_USERNS=keep-id podman-compose up`
+
+    volumes:
+      - ${DB_PATH_AT_HOST}/data:/var/lib/postgresql/data
+    healthcheck:
+      test: pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}
+      interval: 30s
+      timeout: 30s
+      retries: 3
+      start_period: 1m

--- a/tools/remove_repos.py
+++ b/tools/remove_repos.py
@@ -1,0 +1,45 @@
+# This file is for removing repo URLs hosted at https://datasets.datalad.org
+# and associated metadata from the database
+
+from datalad.utils import rmtree as rm_ds_tree
+from sqlalchemy import select
+
+from datalad_registry import create_app
+from datalad_registry.models import RepoUrl, db
+
+flask_app = create_app()
+
+with flask_app.app_context():
+
+    # Get all repo URLs that start with https://datasets.datalad.org
+    repo_urls = (
+        db.session.execute(
+            select(RepoUrl).filter(
+                RepoUrl.url.startswith("https://datasets.datalad.org")
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    print(f"deleting {len(repo_urls)} repo URLs\n")
+
+    # Delete all the repo URLs and associated metadata
+    for repo_url in repo_urls:
+
+        # Remove the dataset from the local cache if exists
+        cache_path_abs = repo_url.cache_path_abs
+        if repo_url.cache_path_abs is not None:
+            print(f"deleting {repo_url.cache_path_abs} from cache .. .")
+            rm_ds_tree(cache_path_abs)
+
+        # Delete associated metadata
+        for md in repo_url.metadata_:
+            db.session.delete(md)
+
+        # Delete the repo URL
+        db.session.delete(repo_url)
+
+    db.session.commit()
+
+    print("done")

--- a/worker-up.sh
+++ b/worker-up.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Default values for parameters
+env_file=""
+pids_limit=""
+
+# Parse keyword arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --env-file) env_file="$2"; shift ;;
+        --pids-limit) pids_limit="$2"; shift ;;
+        *) echo "Unknown parameter: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Check if required parameters are provided
+if [ -z "$env_file" ] || [ -z "$pids_limit" ]; then
+    echo "Usage: $0 --env-file path_to_env_file --pids-limit pids_limit"
+    exit 1
+fi
+
+# Load environment variables from the provided file
+set -a && source "$env_file" && set +a
+
+# Run the podman command with the PID limit
+podman run -d \
+  --name datalad-registry_worker_1 \
+  --network datalad-registry_default \
+  --network-alias worker \
+  --pids-limit "$pids_limit" \
+  -v "${WORKER_PATH_AT_HOST}/data/cache:/data/cache" \
+  -e FLASK_APP=datalad_registry:create_app \
+  -e DATALAD_REGISTRY_OPERATION_MODE="${DATALAD_REGISTRY_OPERATION_MODE}" \
+  -e DATALAD_REGISTRY_INSTANCE_PATH=/app/instance \
+  -e DATALAD_REGISTRY_DATASET_CACHE=/data/cache \
+  -e CELERY_BROKER_URL="${CELERY_BROKER_URL}" \
+  -e CELERY_RESULT_BACKEND=redis://backend:6379 \
+  -e SQLALCHEMY_DATABASE_URI="${SQLALCHEMY_DATABASE_URI}" \
+  --health-cmd="celery -A datalad_registry.make_celery:celery_app status --timeout 1 --json | grep pong" \
+  --health-interval=30s \
+  --health-retries=3 \
+  --health-start-period=3m \
+  --health-timeout=30s \
+  datalad-registry:dev \
+  bash -c "celery -A datalad_registry.make_celery:celery_app worker --loglevel DEBUG --pool prefork"


### PR DESCRIPTION
This PR provides a workaround solution to set the PID limit of the worker service container. This workaround is needed because currently Podman Compose, as of version `1.0.6`, doesn't support setting of the PID limit by the [`pid_limit` key](https://docs.docker.com/compose/compose-file/05-services/#pids_limit) or the [`deploy.reservations.pids` key](https://docs.docker.com/compose/compose-file/05-services/#pids_limit).

This solution provides `docker-compose.dev.no-worker.yml` to bring up all services in Datalad-Registry except the worker service and `worker-up.sh` to bring up the worker service with option to choose the PID limit using the `--pids-limit` option.

Note: 
1. A request has been made to the `podman-compose` project to add support of setting the PID limit of a service container. (https://github.com/containers/podman-compose/issues/806)
2. Additionally, this workaround will not be needed as soon as `Podman` is update to version 4.4 or later, https://docs.podman.io/en/v4.4/markdown/podman-update.1.html#pids-limit-limit.