### PR TITLE
Include the python3-gdbm package in Docker image

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -19,6 +19,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
       libpq-dev \
       python3-dev \
       python3-pip \
+      python3-gdbm \
       && \
     DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Including the python3-gdbm package significantly improves the performance of the monitor, Flower, service, particularly in DB queries.