### PR TITLE
Ensuring container services having the correct init process and other improvements related to container services

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 # TODO: Consider removing the eatmydata dependency. It may not be needed.
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends eatmydata && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \
     DEBIAN_FRONTEND=noninteractive eatmydata apt-get install -y --no-install-recommends gnupg locales && \
     echo "en_US.UTF-8 UTF-8" >>/etc/locale.gen && locale-gen && \
     DEBIAN_FRONTEND=noninteractive eatmydata apt-get install -y --no-install-recommends \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -5,6 +5,12 @@
 FROM docker.io/phusion/baseimage:jammy-1.0.1
 WORKDIR /app
 
+# A workaround for setting the HOME environment variable
+# when /sbin/my_init is used as the init process.
+# See https://github.com/phusion/baseimage-docker?tab=readme-ov-file#environment-variables
+# for more information.
+RUN echo /root > /etc/container_environment/HOME
+
 # Install dependencies
 # TODO: Consider removing the eatmydata dependency. It may not be needed.
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \

--- a/docker-compose.dev.local.override.yml
+++ b/docker-compose.dev.local.override.yml
@@ -4,8 +4,11 @@
 
 services:
   web:
-    command: [ "bash", "-c",
-               "git config --global --add safe.directory /app && pip3 install -U -e . && flask init-db && flask run --host=0.0.0.0 --debug" ]
+    command: [
+      "/sbin/my_init", "--",
+      "bash", "-c",
+      "git config --global --add safe.directory /app && pip3 install -U -e . && flask init-db && exec flask run --host=0.0.0.0 --debug"
+    ]
     volumes:
       - ./:/app
       - ./instance:/app/instance

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,7 +25,7 @@ services:
 
       # db service access info
       SQLALCHEMY_DATABASE_URI: "${SQLALCHEMY_DATABASE_URI}"
-    command: [ "bash", "-c", "flask init-db && flask run --host=0.0.0.0" ]
+    command: [ "/sbin/my_init", "--", "bash", "-c", "flask init-db && flask run --host=0.0.0.0" ]
     volumes:
       - ${WEB_PATH_AT_HOST}/instance:/app/instance
 
@@ -37,6 +37,7 @@ services:
       db:
         condition: service_healthy
     command: [
+      "/sbin/my_init", "--",
       "bash", "-c",
       "celery -A datalad_registry.make_celery:celery_app worker --loglevel INFO --pool prefork"
     ]
@@ -57,6 +58,7 @@ services:
       broker:
         condition: service_healthy
     command: [
+      "/sbin/my_init", "--",
       "bash", "-c",
       "celery -A datalad_registry.make_celery:celery_app beat -s /data/celerybeat-schedule -l INFO"
     ]
@@ -87,7 +89,7 @@ services:
       FLOWER_BASIC_AUTH: "$FLOWER_BASIC_AUTH"
     ports:
       - "127.0.0.1:5555:5555"
-    command: [ "bash", "-c", "celery -A datalad_registry.make_celery:celery_app flower" ]
+    command: [ "/sbin/my_init", "--", "bash", "-c", "celery -A datalad_registry.make_celery:celery_app flower" ]
     volumes:
       - ${MONITOR_PATH_AT_HOST}/data:/data
     healthcheck:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,7 +25,7 @@ services:
 
       # db service access info
       SQLALCHEMY_DATABASE_URI: "${SQLALCHEMY_DATABASE_URI}"
-    command: [ "/sbin/my_init", "--", "bash", "-c", "flask init-db && flask run --host=0.0.0.0" ]
+    command: [ "/sbin/my_init", "--", "bash", "-c", "flask init-db && exec flask run --host=0.0.0.0" ]
     volumes:
       - ${WEB_PATH_AT_HOST}/instance:/app/instance
 
@@ -39,7 +39,7 @@ services:
     command: [
       "/sbin/my_init", "--",
       "bash", "-c",
-      "celery -A datalad_registry.make_celery:celery_app worker --loglevel INFO --pool prefork"
+      "exec celery -A datalad_registry.make_celery:celery_app worker --loglevel INFO --pool prefork"
     ]
     volumes:
       - ${WORKER_PATH_AT_HOST}/data/cache:/data/cache
@@ -60,7 +60,7 @@ services:
     command: [
       "/sbin/my_init", "--",
       "bash", "-c",
-      "celery -A datalad_registry.make_celery:celery_app beat -s /data/celerybeat-schedule -l INFO"
+      "exec celery -A datalad_registry.make_celery:celery_app beat -s /data/celerybeat-schedule -l INFO"
     ]
     volumes:
       - ${SCHEDULER_PATH_AT_HOST}/data:/data
@@ -89,7 +89,7 @@ services:
       FLOWER_BASIC_AUTH: "$FLOWER_BASIC_AUTH"
     ports:
       - "127.0.0.1:5555:5555"
-    command: [ "/sbin/my_init", "--", "bash", "-c", "celery -A datalad_registry.make_celery:celery_app flower" ]
+    command: [ "/sbin/my_init", "--", "bash", "-c", "exec celery -A datalad_registry.make_celery:celery_app flower" ]
     volumes:
       - ${MONITOR_PATH_AT_HOST}/data:/data
     healthcheck:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,8 +38,7 @@ services:
         condition: service_healthy
     command: [
       "/sbin/my_init", "--",
-      "bash", "-c",
-      "exec celery -A datalad_registry.make_celery:celery_app worker --loglevel INFO --pool prefork"
+      "celery", "-A", "datalad_registry.make_celery:celery_app", "worker", "--loglevel", "INFO", "--pool", "prefork"
     ]
     volumes:
       - ${WORKER_PATH_AT_HOST}/data/cache:/data/cache
@@ -59,8 +58,7 @@ services:
         condition: service_healthy
     command: [
       "/sbin/my_init", "--",
-      "bash", "-c",
-      "exec celery -A datalad_registry.make_celery:celery_app beat -s /data/celerybeat-schedule -l INFO"
+      "celery", "-A", "datalad_registry.make_celery:celery_app", "beat", "-s", "/data/celerybeat-schedule", "-l", "INFO"
     ]
     volumes:
       - ${SCHEDULER_PATH_AT_HOST}/data:/data
@@ -89,7 +87,7 @@ services:
       FLOWER_BASIC_AUTH: "$FLOWER_BASIC_AUTH"
     ports:
       - "127.0.0.1:5555:5555"
-    command: [ "/sbin/my_init", "--", "bash", "-c", "exec celery -A datalad_registry.make_celery:celery_app flower" ]
+    command: [ "/sbin/my_init", "--", "celery", "-A", "datalad_registry.make_celery:celery_app", "flower" ]
     volumes:
       - ${MONITOR_PATH_AT_HOST}/data:/data
     healthcheck:

--- a/docker-compose.read-only.local.override.yml
+++ b/docker-compose.read-only.local.override.yml
@@ -5,8 +5,11 @@
 
 services:
   read-only-web:
-    command: [ "bash", "-c",
-               "pip3 install -U -e . && flask init-db && flask run --host=0.0.0.0 --debug" ]
+    command: [
+      "/sbin/my_init", "--",
+      "bash", "-c",
+      "pip3 install -U -e . && flask init-db && exec flask run --host=0.0.0.0 --debug"
+    ]
 
     volumes:
       - ./:/app


### PR DESCRIPTION
This PR contains the following improvements in container services specification.

1. Container services are now utilizing the init process provided by https://github.com/phusion/baseimage-docker to ensure all orphaned processes are reaped. Thus, this PR closes https://github.com/datalad/datalad-registry/issues/283.
2. Elimination of the calls to `bash` in invoking the command to be executed for a container when the calls can be avoided.
3. The use of `exec` to ensure a `SIGTERM` signal is received by the target process of a container when `docker/podman stop` are used.
4. Upgrading the operating system inside the container when building the container images. This improve the security of the container. See https://github.com/phusion/baseimage-docker?tab=readme-ov-file#upgrading-the-operating-system-inside-the-container for more information