### PR TITLE
Sync Datalad-Registry with datalad-usage-dashboard

### DIFF
--- a/datalad_registry/blueprints/api/__init__.py
+++ b/datalad_registry/blueprints/api/__init__.py
@@ -2,6 +2,10 @@ from pydantic import BaseModel, Field
 
 API_URL_PREFIX = "/api/v2"
 
+# The path of the dataset URL resources on the DataLad Registry instance relative to
+# the base API endpoint of the instance.
+DATASET_URLS_PATH = "dataset-urls"
+
 
 class HTTPExceptionResp(BaseModel):
     """

--- a/datalad_registry/blueprints/api/__init__.py
+++ b/datalad_registry/blueprints/api/__init__.py
@@ -6,6 +6,10 @@ API_URL_PREFIX = "/api/v2"
 # the base API endpoint of the instance.
 DATASET_URLS_PATH = "dataset-urls"
 
+# The path of the URL metadata resources on the DataLad Registry instance relative to
+# the base API endpoint of the instance.
+URL_METADATA_PATH = "url-metadata"
+
 
 class HTTPExceptionResp(BaseModel):
     """

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -31,7 +31,12 @@ from .models import (
     PathParams,
     QueryParams,
 )
-from .. import API_URL_PREFIX, COMMON_API_RESPONSES, HTTPExceptionResp
+from .. import (
+    API_URL_PREFIX,
+    COMMON_API_RESPONSES,
+    DATASET_URLS_PATH,
+    HTTPExceptionResp,
+)
 from ..url_metadata.models import URLMetadataRef
 from ..utils import disable_in_read_only_mode
 
@@ -43,11 +48,6 @@ _ORDER_KEY_TO_SQLA_ATTR = {
     OrderKey.last_update: RepoUrl.last_update_dt,
     OrderKey.git_objects_kb: RepoUrl.git_objects_kb,
 }
-
-# The path of the dataset URLs resource on the DataLad Registry instance relative to
-# the base API endpoint of the instance.
-DATASET_URLS_PATH = "dataset-urls"
-
 
 bp = APIBlueprint(
     "dataset_urls_api",

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -44,10 +44,15 @@ _ORDER_KEY_TO_SQLA_ATTR = {
     OrderKey.git_objects_kb: RepoUrl.git_objects_kb,
 }
 
+# The path of the dataset URLs resource on the DataLad Registry instance relative to
+# the base API endpoint of the instance.
+DATASET_URLS_PATH = "dataset-urls"
+
+
 bp = APIBlueprint(
     "dataset_urls_api",
     __name__,
-    url_prefix=f"{API_URL_PREFIX}/dataset-urls",
+    url_prefix=f"{API_URL_PREFIX}/{DATASET_URLS_PATH}",
     abp_tags=[Tag(name="Dataset URLs", description="API endpoints for dataset URLs")],
     abp_responses=COMMON_API_RESPONSES,
 )

--- a/datalad_registry/blueprints/api/url_metadata/__init__.py
+++ b/datalad_registry/blueprints/api/url_metadata/__init__.py
@@ -6,12 +6,12 @@ from flask_openapi3 import APIBlueprint, Tag
 from datalad_registry.models import URLMetadata, db
 
 from .models import PathParams, URLMetadataModel
-from .. import API_URL_PREFIX, COMMON_API_RESPONSES
+from .. import API_URL_PREFIX, COMMON_API_RESPONSES, URL_METADATA_PATH
 
 bp = APIBlueprint(
     "url_metadata_api",
     __name__,
-    url_prefix=f"{API_URL_PREFIX}/url-metadata",
+    url_prefix=f"{API_URL_PREFIX}/{URL_METADATA_PATH}",
     abp_tags=[Tag(name="URL Metadata", description="API endpoints for URL metadata")],
     abp_responses=COMMON_API_RESPONSES,
 )

--- a/datalad_registry/conf.py
+++ b/datalad_registry/conf.py
@@ -118,7 +118,9 @@ class TestingConfig(BaseConfig):
     # Web service is not available in testing mode.
     # The following overrides unneeded fields from `BaseConfig` with default values
     # to make them optional.
-    DATALAD_REGISTRY_WEB_API_URL: AnyHttpUrl = "http://dummy.url"
+    DATALAD_REGISTRY_WEB_API_URL: AnyHttpUrl = AnyHttpUrl(
+        url="http://dummy.url", scheme="http"
+    )
 
     TESTING: bool = True
 
@@ -137,7 +139,9 @@ class ReadOnlyConfig(BaseConfig):
     # The following overrides unneeded fields from `BaseConfig` with default values
     # to make them optional.
     DATALAD_REGISTRY_DATASET_CACHE: Path = Path("/dummy/path")
-    DATALAD_REGISTRY_WEB_API_URL: AnyHttpUrl = "http://dummy.url"
+    DATALAD_REGISTRY_WEB_API_URL: AnyHttpUrl = AnyHttpUrl(
+        url="http://dummy.url", scheme="http"
+    )
     CELERY_BROKER_URL: str = "dummy://"
     CELERY_RESULT_BACKEND: str = "dummy://"
 

--- a/datalad_registry/conf.py
+++ b/datalad_registry/conf.py
@@ -115,6 +115,11 @@ class TestingConfig(BaseConfig):
     # Restrict to operation mode appropriate for this type of configuration
     DATALAD_REGISTRY_OPERATION_MODE: Literal[OperationMode.TESTING]
 
+    # Web service is not available in testing mode.
+    # The following overrides unneeded fields from `BaseConfig` with default values
+    # to make them optional.
+    DATALAD_REGISTRY_WEB_API_URL: AnyHttpUrl = "http://dummy.url"
+
     TESTING: bool = True
 
 

--- a/datalad_registry/conf.py
+++ b/datalad_registry/conf.py
@@ -30,6 +30,11 @@ class BaseConfig(OperationConfig):
     DATALAD_REGISTRY_MAX_URL_CHKS_ISSUED_PER_DISPATCH_CYCLE: NonNegativeInt = 10
     DATALAD_REGISTRY_DISPATCH_CYCLE_LENGTH: PositiveFloat = 60.0  # seconds
 
+    # Configurations related to syncing with the usage dashboard
+    DATALAD_REGISTRY_USAGE_DASHBOARD_SYNC_CYCLE_LENGTH: PositiveFloat = (
+        60.0 * 60 * 24
+    )  # A day in seconds
+
     # Metadata extractors to use
     DATALAD_REGISTRY_METADATA_EXTRACTORS: list[str] = [
         "metalad_core",
@@ -56,7 +61,14 @@ class BaseConfig(OperationConfig):
                     "task": "datalad_registry.tasks.url_chk_dispatcher",
                     "schedule": self.DATALAD_REGISTRY_DISPATCH_CYCLE_LENGTH,
                     "options": {"expires": self.DATALAD_REGISTRY_DISPATCH_CYCLE_LENGTH},
-                }
+                },
+                "usage-dashboard-sync": {
+                    "task": "datalad_registry.tasks.usage_dashboard_sync",
+                    "schedule": self.DATALAD_REGISTRY_USAGE_DASHBOARD_SYNC_CYCLE_LENGTH,
+                    "options": {
+                        "expires": self.DATALAD_REGISTRY_USAGE_DASHBOARD_SYNC_CYCLE_LENGTH
+                    },
+                },
             },
             task_ignore_result=True,
             worker_max_tasks_per_child=1000,

--- a/datalad_registry/conf.py
+++ b/datalad_registry/conf.py
@@ -134,12 +134,10 @@ class ReadOnlyConfig(BaseConfig):
     DATALAD_REGISTRY_OPERATION_MODE: Literal[OperationMode.READ_ONLY]
 
     # The Celery service is not available in read-only mode.
-    # The following are just dummy values to serve as defaults to satisfy
-    # the configuration requirements and make the corresponding fields optional.
+    # The following overrides unneeded fields from `BaseConfig` with default values
+    # to make them optional.
     DATALAD_REGISTRY_DATASET_CACHE: Path = Path("/dummy/path")
-
     DATALAD_REGISTRY_WEB_API_URL: AnyHttpUrl = "http://dummy.url"
-
     CELERY_BROKER_URL: str = "dummy://"
     CELERY_RESULT_BACKEND: str = "dummy://"
 

--- a/datalad_registry/conf.py
+++ b/datalad_registry/conf.py
@@ -2,7 +2,14 @@ from enum import auto
 from pathlib import Path
 from typing import Any, Literal, Union
 
-from pydantic import BaseSettings, NonNegativeInt, PositiveFloat, PostgresDsn, validator
+from pydantic import (
+    AnyHttpUrl,
+    BaseSettings,
+    NonNegativeInt,
+    PositiveFloat,
+    PostgresDsn,
+    validator,
+)
 
 from datalad_registry.utils.misc import StrEnum
 
@@ -23,6 +30,9 @@ class OperationConfig(BaseSettings):
 class BaseConfig(OperationConfig):
     DATALAD_REGISTRY_INSTANCE_PATH: Path
     DATALAD_REGISTRY_DATASET_CACHE: Path
+
+    # URL for any service to reach the web service API of the DataLad-Registry instance
+    DATALAD_REGISTRY_WEB_API_URL: AnyHttpUrl
 
     # URL check dispatcher related configuration
     DATALAD_REGISTRY_MIN_CHK_INTERVAL_PER_URL: NonNegativeInt = 3600  # seconds
@@ -122,6 +132,8 @@ class ReadOnlyConfig(BaseConfig):
     # The following are just dummy values to serve as defaults to satisfy
     # the configuration requirements and make the corresponding fields optional.
     DATALAD_REGISTRY_DATASET_CACHE: Path = Path("/dummy/path")
+
+    DATALAD_REGISTRY_WEB_API_URL: AnyHttpUrl = "http://dummy.url"
 
     CELERY_BROKER_URL: str = "dummy://"
     CELERY_RESULT_BACKEND: str = "dummy://"

--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -640,7 +640,7 @@ def chk_url_to_update(
 
 class FailedSubmission(TypedDict):
     """
-    A TypedDict a failed submission of a repo URL to Datalad-Registry
+    A failed submission of a repo URL to Datalad-Registry
     """
 
     status_code: int

--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -18,7 +18,6 @@ import requests
 from sqlalchemy import and_, case, not_, or_, select
 from yarl import URL
 
-from datalad_registry.blueprints.api.dataset_urls import DATASET_URLS_PATH
 from datalad_registry.com_models import MetaExtractResult
 from datalad_registry.models import RepoUrl, URLMetadata, db
 from datalad_registry.utils import StrEnum
@@ -35,6 +34,7 @@ from .utils import allocate_ds_path, update_ds_clone, validate_url_is_processed
 from .utils.builtin_meta_extractors import EXTRACTOR_MAP as BUILTIN_EXTRACTOR_MAP
 from .utils.builtin_meta_extractors import InvalidRequiredFileError, dlreg_meta_extract
 from .utils.usage_dashboard import DASHBOARD_COLLECTION_URL, DashboardCollection, Status
+from ..blueprints.api import DATASET_URLS_PATH
 
 lgr = get_task_logger(__name__)
 

--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -642,5 +642,7 @@ def usage_dashboard_sync() -> None:
 
     Note: Syncing in this context means ensuring all the active repositories listed in
           datalad-usage-dashboard are registered in Datalad-Registry.
+    Note: Currently, this script excludes the OSF repositories listed in the
+          datalad-usage-dashboard.
     """
     pass

--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -645,4 +645,16 @@ def usage_dashboard_sync() -> None:
     Note: Currently, this script excludes the OSF repositories listed in the
           datalad-usage-dashboard.
     """
+    # Fetch repositories from datalad-usage-dashboard
+    # Filter out non-active repositories
+
+    # Fetch repositories from database
+
+    # Calculate the set of active repositories that exist in the usage dashboard
+    # but not in the database
+
+    # Submit (register) this set of repositories to Datalad-Registry through the web API
+
+    # Return the result of the submissions
+
     pass

--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -633,6 +633,13 @@ def chk_url_to_update(
     return ChkUrlStatus.OK_UPDATED if is_record_updated else ChkUrlStatus.OK_CHK_ONLY
 
 
+# URL of the JSON representation of all the repositories in the datalad-usage-dashboard
+DASHBOARD_COLLECTION_URL = (
+    "https://raw.githubusercontent.com/datalad/"
+    "datalad-usage-dashboard/master/datalad-repos.json"
+)
+
+
 @shared_task
 def usage_dashboard_sync() -> None:
     """

--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -631,3 +631,16 @@ def chk_url_to_update(
         db.session.commit()
 
     return ChkUrlStatus.OK_UPDATED if is_record_updated else ChkUrlStatus.OK_CHK_ONLY
+
+
+@shared_task
+def usage_dashboard_sync() -> None:
+    """
+    A task intended to be periodically initiated by the scheduler service to sync
+    Datalad-Registry with the datalad-usage-dashboard,
+    https://github.com/datalad/datalad-usage-dashboard.
+
+    Note: Syncing in this context means ensuring all the active datasets in
+          datalad-usage-dashboard are registered in Datalad-Registry.
+    """
+    pass

--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -633,13 +633,6 @@ def chk_url_to_update(
     return ChkUrlStatus.OK_UPDATED if is_record_updated else ChkUrlStatus.OK_CHK_ONLY
 
 
-# URL of the JSON representation of all the repositories in the datalad-usage-dashboard
-DASHBOARD_COLLECTION_URL = (
-    "https://raw.githubusercontent.com/datalad/"
-    "datalad-usage-dashboard/master/datalad-repos.json"
-)
-
-
 @shared_task
 def usage_dashboard_sync() -> None:
     """

--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -16,7 +16,9 @@ from flask import current_app
 from pydantic import StrictInt, StrictStr, parse_obj_as, validate_arguments
 import requests
 from sqlalchemy import and_, case, not_, or_, select
+from yarl import URL
 
+from datalad_registry.blueprints.api.dataset_urls import DATASET_URLS_PATH
 from datalad_registry.com_models import MetaExtractResult
 from datalad_registry.models import RepoUrl, URLMetadata, db
 from datalad_registry.utils import StrEnum
@@ -702,9 +704,13 @@ def usage_dashboard_sync() -> UsageDashboardSyncResult:
         update_requested_repos: list[str] = []
         failed_submissions: list[FailedSubmission] = []
 
+        submission_endpoint = str(
+            URL(str(current_app.config["DATALAD_REGISTRY_WEB_API_URL"]))
+            / DATASET_URLS_PATH
+        )
         for repo in active_repos_to_register:
             resp = session.post(
-                "http://web:5000/api/v2" + "/dataset-urls",  # todo: Replace hard-coded
+                submission_endpoint,
                 json={"url": repo},
             )
 

--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -640,7 +640,7 @@ def usage_dashboard_sync() -> None:
     Datalad-Registry with the datalad-usage-dashboard,
     https://github.com/datalad/datalad-usage-dashboard.
 
-    Note: Syncing in this context means ensuring all the active datasets in
+    Note: Syncing in this context means ensuring all the active repositories listed in
           datalad-usage-dashboard are registered in Datalad-Registry.
     """
     pass

--- a/datalad_registry/tasks/utils/usage_dashboard.py
+++ b/datalad_registry/tasks/utils/usage_dashboard.py
@@ -1,0 +1,9 @@
+# This file contains definitions for accessing information made available
+# by the datalad-usage-dashboard, https://github.com/datalad/datalad-usage-dashboard.
+
+
+# URL of the JSON representation of all the repositories in the datalad-usage-dashboard
+DASHBOARD_COLLECTION_URL = (
+    "https://raw.githubusercontent.com/datalad/"
+    "datalad-usage-dashboard/master/datalad-repos.json"
+)

--- a/datalad_registry/tasks/utils/usage_dashboard.py
+++ b/datalad_registry/tasks/utils/usage_dashboard.py
@@ -1,5 +1,6 @@
 # This file contains definitions for accessing information made available
 # by the datalad-usage-dashboard, https://github.com/datalad/datalad-usage-dashboard.
+import abc
 from enum import auto
 from typing import Optional
 
@@ -23,7 +24,7 @@ class Status(StrEnum):
     gone = auto()
 
 
-class Repo(BaseModel):
+class Repo(BaseModel, abc.ABC):
     """
     Pydantic model for representing a git repo represented
     in the datalad-usage-dashboard
@@ -32,6 +33,14 @@ class Repo(BaseModel):
     name: StrictStr
     url: HttpUrl
     status: Status
+
+    @property
+    @abc.abstractmethod
+    def clone_url(self) -> str:
+        """
+        The URL used for cloning the repo
+        """
+        pass
 
 
 class GHRepo(Repo):
@@ -46,6 +55,10 @@ class GHRepo(Repo):
     run: bool
     container_run: bool
 
+    @property
+    def clone_url(self) -> str:
+        return str(self.url) + ".git"
+
 
 class OSFRepo(Repo):
     """
@@ -54,6 +67,10 @@ class OSFRepo(Repo):
     """
 
     id: StrictStr
+
+    @property
+    def clone_url(self) -> str:
+        raise NotImplementedError
 
 
 class GinRepo(Repo):
@@ -64,6 +81,10 @@ class GinRepo(Repo):
 
     id: StrictInt
     stars: StrictInt
+
+    @property
+    def clone_url(self) -> str:
+        return str(self.url)
 
 
 class DashboardCollection(BaseModel):

--- a/datalad_registry/tasks/utils/usage_dashboard.py
+++ b/datalad_registry/tasks/utils/usage_dashboard.py
@@ -1,9 +1,20 @@
 # This file contains definitions for accessing information made available
 # by the datalad-usage-dashboard, https://github.com/datalad/datalad-usage-dashboard.
+from enum import auto
 
+from datalad_registry.utils import StrEnum
 
 # URL of the JSON representation of all the repositories in the datalad-usage-dashboard
 DASHBOARD_COLLECTION_URL = (
     "https://raw.githubusercontent.com/datalad/"
     "datalad-usage-dashboard/master/datalad-repos.json"
 )
+
+
+class Status(StrEnum):
+    """
+    Enum for representing the status of repo
+    """
+
+    active = auto()
+    gone = auto()

--- a/datalad_registry/tasks/utils/usage_dashboard.py
+++ b/datalad_registry/tasks/utils/usage_dashboard.py
@@ -1,8 +1,9 @@
 # This file contains definitions for accessing information made available
 # by the datalad-usage-dashboard, https://github.com/datalad/datalad-usage-dashboard.
 from enum import auto
+from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, HttpUrl, StrictInt, StrictStr
 
 from datalad_registry.utils import StrEnum
 
@@ -28,7 +29,9 @@ class Repo(BaseModel):
     in the datalad-usage-dashboard
     """
 
-    pass
+    name: StrictStr
+    url: HttpUrl
+    status: Status
 
 
 class GHRepo(Repo):
@@ -37,7 +40,11 @@ class GHRepo(Repo):
     in the datalad-usage-dashboard
     """
 
-    pass
+    id: Optional[StrictInt]
+    stars: StrictInt
+    dataset: bool
+    run: bool
+    container_run: bool
 
 
 class OSFRepo(Repo):
@@ -46,7 +53,7 @@ class OSFRepo(Repo):
     in the datalad-usage-dashboard
     """
 
-    pass
+    id: StrictStr
 
 
 class GinRepo(Repo):
@@ -55,7 +62,8 @@ class GinRepo(Repo):
     in the datalad-usage-dashboard
     """
 
-    pass
+    id: StrictInt
+    stars: StrictInt
 
 
 class DashboardCollection(BaseModel):

--- a/datalad_registry/tasks/utils/usage_dashboard.py
+++ b/datalad_registry/tasks/utils/usage_dashboard.py
@@ -56,3 +56,14 @@ class GinRepo(Repo):
     """
 
     pass
+
+
+class DashboardCollection(BaseModel):
+    """
+    Pydantic model for representing the collection of git repos represented
+    in the datalad-usage-dashboard
+    """
+
+    github: list[GHRepo]
+    osf: list[OSFRepo]
+    gin: list[GinRepo]

--- a/datalad_registry/tasks/utils/usage_dashboard.py
+++ b/datalad_registry/tasks/utils/usage_dashboard.py
@@ -2,6 +2,8 @@
 # by the datalad-usage-dashboard, https://github.com/datalad/datalad-usage-dashboard.
 from enum import auto
 
+from pydantic import BaseModel
+
 from datalad_registry.utils import StrEnum
 
 # URL of the JSON representation of all the repositories in the datalad-usage-dashboard
@@ -18,3 +20,39 @@ class Status(StrEnum):
 
     active = auto()
     gone = auto()
+
+
+class Repo(BaseModel):
+    """
+    Pydantic model for representing a git repo represented
+    in the datalad-usage-dashboard
+    """
+
+    pass
+
+
+class GHRepo(Repo):
+    """
+    Pydantic model for representing a git repo residing on GitHub represented
+    in the datalad-usage-dashboard
+    """
+
+    pass
+
+
+class OSFRepo(Repo):
+    """
+    Pydantic model for representing a git repo residing on OSF represented
+    in the datalad-usage-dashboard
+    """
+
+    pass
+
+
+class GinRepo(Repo):
+    """
+    Pydantic model for representing a git repo residing on GIN represented
+    in the datalad-usage-dashboard
+    """
+
+    pass

--- a/datalad_registry/tests/test__init__.py
+++ b/datalad_registry/tests/test__init__.py
@@ -12,12 +12,47 @@ from datalad_registry.conf import BaseConfig, OperationMode
 
 class TestCreateApp:
     @pytest.mark.parametrize(
-        ("op_mode", "instance_path", "cache_path", "broker_url", "result_backend"),
+        (
+            "op_mode",
+            "instance_path",
+            "cache_path",
+            "web_api_url",
+            "broker_url",
+            "result_backend",
+        ),
         [
-            ("PRODUCTION", "/a/b", "/c/d", "redis://localhost", "redis://localhost"),
-            ("DEVELOPMENT", "/a", "/", "redis://localhost", "redis://localhost"),
-            ("TESTING", "/a/b/c", "/c/d/", "redis://localhost", "redis://localhost"),
-            ("READ_ONLY", "/ab", "/cd", "redis://localhost", "redis://localhost"),
+            (
+                "PRODUCTION",
+                "/a/b",
+                "/c/d",
+                "http://web:5000/api/v2",
+                "redis://localhost",
+                "redis://localhost",
+            ),
+            (
+                "DEVELOPMENT",
+                "/a",
+                "/",
+                "http://web/api/v2",
+                "redis://localhost",
+                "redis://localhost",
+            ),
+            (
+                "TESTING",
+                "/a/b/c",
+                "/c/d/",
+                "http://web",
+                "redis://localhost",
+                "redis://localhost",
+            ),
+            (
+                "READ_ONLY",
+                "/ab",
+                "/cd",
+                "https://web:5000/api/v2",
+                "redis://localhost",
+                "redis://localhost",
+            ),
         ],
     )
     def test_configuration(
@@ -25,6 +60,7 @@ class TestCreateApp:
         op_mode,
         instance_path,
         cache_path,
+        web_api_url,
         broker_url,
         result_backend,
         monkeypatch,
@@ -60,6 +96,7 @@ class TestCreateApp:
                 DATALAD_REGISTRY_OPERATION_MODE=op_mode,
                 DATALAD_REGISTRY_INSTANCE_PATH=instance_path,
                 DATALAD_REGISTRY_DATASET_CACHE=cache_path,
+                DATALAD_REGISTRY_WEB_API_URL=web_api_url,
                 CELERY_BROKER_URL=broker_url,
                 CELERY_RESULT_BACKEND=result_backend,
                 SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://usr:pd@db:5432/dbn",
@@ -89,6 +126,7 @@ class TestCreateApp:
         )
         assert flask_app.config["DATALAD_REGISTRY_INSTANCE_PATH"] == Path(instance_path)
         assert flask_app.config["DATALAD_REGISTRY_DATASET_CACHE"] == Path(cache_path)
+        assert str(flask_app.config["DATALAD_REGISTRY_WEB_API_URL"]) == web_api_url
         assert flask_app.config["DATALAD_REGISTRY_MIN_CHK_INTERVAL_PER_URL"] == 3600
         assert flask_app.config["DATALAD_REGISTRY_MAX_FAILED_CHKS_PER_URL"] == 10
         assert (

--- a/datalad_registry/tests/test__init__.py
+++ b/datalad_registry/tests/test__init__.py
@@ -38,7 +38,12 @@ class TestCreateApp:
                 "task": "datalad_registry.tasks.url_chk_dispatcher",
                 "schedule": 60.0,
                 "options": {"expires": 60.0},
-            }
+            },
+            "usage-dashboard-sync": {
+                "task": "datalad_registry.tasks.usage_dashboard_sync",
+                "schedule": 60.0 * 60 * 24,
+                "options": {"expires": 60.0 * 60 * 24},
+            },
         }
 
         default_metadata_extractors = [

--- a/datalad_registry/tests/test_conf.py
+++ b/datalad_registry/tests/test_conf.py
@@ -32,6 +32,7 @@ class TestBaseConfig:
         # noinspection PyTypeChecker
         config = BaseConfig(
             DATALAD_REGISTRY_OPERATION_MODE=OperationMode.PRODUCTION,
+            DATALAD_REGISTRY_WEB_API_URL="http://web/api",
             CELERY_BROKER_URL="redis://localhost",
             CELERY_RESULT_BACKEND="redis://localhost",
             SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://usr:pd@db:5432/dbn",
@@ -136,6 +137,7 @@ class TestBaseConfig:
             DATALAD_REGISTRY_OPERATION_MODE=OperationMode.PRODUCTION,
             DATALAD_REGISTRY_INSTANCE_PATH=Path("/a/b"),
             DATALAD_REGISTRY_DATASET_CACHE=Path("/a/b"),
+            DATALAD_REGISTRY_WEB_API_URL="http://web/api",
             SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://usr:pd@db:5432/dbn",
         ).CELERY == dict(
             broker_url=expected_broker_url,
@@ -165,6 +167,7 @@ class TestUpperLevelConfigs:
             DATALAD_REGISTRY_OPERATION_MODE=OperationMode(operation_mode),
             DATALAD_REGISTRY_INSTANCE_PATH=Path("/a/b"),
             DATALAD_REGISTRY_DATASET_CACHE=Path("/a/b"),
+            DATALAD_REGISTRY_WEB_API_URL="http://web/api",
             CELERY_BROKER_URL="redis://localhost",
             CELERY_RESULT_BACKEND="redis://localhost",
             SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://usr:pd@db:5432/dbn",
@@ -177,6 +180,7 @@ class TestUpperLevelConfigs:
             config = config_cls(
                 DATALAD_REGISTRY_INSTANCE_PATH=Path("/a/b"),
                 DATALAD_REGISTRY_DATASET_CACHE=Path("/a/b"),
+                DATALAD_REGISTRY_WEB_API_URL="http://web/api",
                 CELERY_BROKER_URL="redis://localhost",
                 CELERY_RESULT_BACKEND="redis://localhost",
                 SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://usr:pd@db:5432/dbn",
@@ -201,6 +205,7 @@ class TestUpperLevelConfigs:
                 DATALAD_REGISTRY_OPERATION_MODE=OperationMode(operation_mode),
                 DATALAD_REGISTRY_INSTANCE_PATH=Path("/a/b"),
                 DATALAD_REGISTRY_DATASET_CACHE=Path("/a/b"),
+                DATALAD_REGISTRY_WEB_API_URL="http://web/api",
                 CELERY_BROKER_URL="redis://localhost",
                 CELERY_RESULT_BACKEND="redis://localhost",
                 SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://usr:pd@db:5432/dbn",
@@ -215,6 +220,7 @@ class TestUpperLevelConfigs:
                 config_cls(
                     DATALAD_REGISTRY_INSTANCE_PATH=Path("/a/b"),
                     DATALAD_REGISTRY_DATASET_CACHE=Path("/a/b"),
+                    DATALAD_REGISTRY_WEB_API_URL="http://web/api",
                     CELERY_BROKER_URL="redis://localhost",
                     CELERY_RESULT_BACKEND="redis://localhost",
                     SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://usr:pd@db:5432/dbn",
@@ -227,6 +233,7 @@ class TestCompileConfigFromEnv:
             "op_mode",
             "instance_path",
             "cache_path",
+            "web_api_url",
             "broker_url",
             "result_backend",
             "sa_db_uri",
@@ -237,6 +244,7 @@ class TestCompileConfigFromEnv:
                 "PRODUCTION",
                 "/a/b",
                 "/c/d",
+                "http://web:5000/api/v2",
                 "redis://localhost",
                 "redis://localhost",
                 "postgresql+psycopg2://user:pd@db:5432/dbn",
@@ -246,6 +254,7 @@ class TestCompileConfigFromEnv:
                 "DEVELOPMENT",
                 "/a",
                 "/",
+                "http://web/api/v2",
                 "redis://localhost",
                 "redis://localhost",
                 "postgresql+psycopg2://usr:passd@db:5432/dbn",
@@ -255,6 +264,7 @@ class TestCompileConfigFromEnv:
                 "TESTING",
                 "/a/b/c",
                 "/c/d/",
+                "http://web",
                 "redis://localhost",
                 "redis://localhost",
                 "postgresql+psycopg2://usr:pd@db:5432/db_name",
@@ -264,6 +274,7 @@ class TestCompileConfigFromEnv:
                 "READ_ONLY",
                 "/ab",
                 "/cd",
+                "https://web:5000/api/v2",
                 "redis://localhost",
                 "redis://localhost",
                 "postgresql+psycopg2://usr:pd@db:1111/dbn",
@@ -276,6 +287,7 @@ class TestCompileConfigFromEnv:
         op_mode,
         instance_path,
         cache_path,
+        web_api_url,
         broker_url,
         result_backend,
         sa_db_uri,
@@ -290,6 +302,7 @@ class TestCompileConfigFromEnv:
         monkeypatch.setenv("DATALAD_REGISTRY_OPERATION_MODE", op_mode)
         monkeypatch.setenv("DATALAD_REGISTRY_INSTANCE_PATH", instance_path)
         monkeypatch.setenv("DATALAD_REGISTRY_DATASET_CACHE", cache_path)
+        monkeypatch.setenv("DATALAD_REGISTRY_WEB_API_URL", web_api_url)
         monkeypatch.setenv("CELERY_BROKER_URL", broker_url)
         monkeypatch.setenv("CELERY_RESULT_BACKEND", result_backend)
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", sa_db_uri)
@@ -299,6 +312,7 @@ class TestCompileConfigFromEnv:
         assert config.DATALAD_REGISTRY_OPERATION_MODE is OperationMode(op_mode)
         assert config.DATALAD_REGISTRY_INSTANCE_PATH == Path(instance_path)
         assert config.DATALAD_REGISTRY_DATASET_CACHE == Path(cache_path)
+        assert str(config.DATALAD_REGISTRY_WEB_API_URL) == web_api_url
         assert config.CELERY_BROKER_URL == broker_url
         assert config.CELERY_RESULT_BACKEND == result_backend
         assert config.SQLALCHEMY_DATABASE_URI == sa_db_uri

--- a/datalad_registry/tests/test_tasks/test_usage_dashboard_sync.py
+++ b/datalad_registry/tests/test_tasks/test_usage_dashboard_sync.py
@@ -91,6 +91,7 @@ def test_usage_dashboard_sync(
     dashboard_collection: str,
     registered_repos: set[str],
     expected_submitted_repos: set[str],
+    flask_app,
 ):
     """
     Test running the Celery task `usage_dashboard_sync`

--- a/datalad_registry/tests/test_tasks/test_usage_dashboard_sync.py
+++ b/datalad_registry/tests/test_tasks/test_usage_dashboard_sync.py
@@ -1,0 +1,109 @@
+import pytest
+
+
+# Use fixture `flask_app` to ensure that the Celery app is initialized,
+# and the db and the cache are clean
+@pytest.mark.usefixtures("flask_app")
+@pytest.mark.parametrize(
+    ("dashboard_collection", "registered_repos", "expected_submitted_repos"),
+    [
+        (
+            """
+                {
+                    "github": [
+                        {
+                            "id": 728117155,
+                            "name": "1104HARI/fail2ban",
+                            "url": "https://github.com/1104HARI/fail2ban",
+                            "stars": 0,
+                            "dataset": false,
+                            "run": true,
+                            "container_run": false,
+                            "status": "active"
+                        },
+                        {
+                            "id": 728117263,
+                            "name": "1104HARI/s3cmd",
+                            "url": "https://github.com/1104HARI/s3cmd",
+                            "stars": 0,
+                            "dataset": false,
+                            "run": true,
+                            "container_run": false,
+                            "status": "active"
+                        },
+                        {
+                            "id": 271283042,
+                            "name": "314eter/recoll",
+                            "url": "https://github.com/314eter/recoll",
+                            "stars": 30,
+                            "dataset": false,
+                            "run": true,
+                            "container_run": false,
+                            "status": "gone"
+                        }
+                    ],
+                    "osf": [
+                        {
+                            "url": "https://osf.io/4cdw3/",
+                            "id": "4cdw3",
+                            "name": "3am-complex-orientation-phantoms",
+                            "status": "active"
+                        },
+                        {
+                            "url": "https://osf.io/u5w4j/",
+                            "id": "u5w4j",
+                            "name": "AOMICPIOP2DemoDataset",
+                            "status": "active"
+                        }
+                    ],
+                    "gin": [
+                        {
+                            "id": 10064,
+                            "name": "AIDAqc_datasets/117_m_RT_Vr",
+                            "url": "https://gin.g-node.org/AIDAqc_datasets/117_m_RT_Vr",
+                            "stars": 0,
+                            "status": "gone"
+                        },
+                        {
+                            "id": 10158,
+                            "name": "AIDAqc_datasets/7_m_RT_Bo",
+                            "url": "https://gin.g-node.org/AIDAqc_datasets/7_m_RT_Bo",
+                            "stars": 0,
+                            "status": "active"
+                        }
+                    ]
+                }
+                """,
+            {
+                "https://github.com/1104HARI/s3cmd.git",
+                "https://gin.g-node.org/AIDAqc_datasets/7_m_RT_Bo",
+                "http://db/example.git",
+            },
+            {
+                "https://github.com/1104HARI/fail2ban.git",
+                "https://github.com/314eter/recoll.git",
+                "https://gin.g-node.org/AIDAqc_datasets/117_m_RT_Vr",
+            },
+        ),
+    ],
+)
+def test_usage_dashboard_sync(
+    dashboard_collection: str,
+    registered_repos: set[str],
+    expected_submitted_repos: set[str],
+    monkeypatch,
+):
+    """
+    Test running the Celery task `usage_dashboard_sync`
+
+    :param dashboard_collection: The JSON string representing the collection
+                                 of git repos in the usage dashboard
+    :param registered_repos: The set of repos, represented in their respective
+                             clone URL, that are already registered in the
+                             Datalad-Registry instance.
+    :param expected_submitted_repos: The set of repos, represented in their respective
+                                     clone URL, that are expected to be submitted to the
+                                     DataLad-Registry instance for registration
+
+    """
+    pass

--- a/datalad_registry/tests/test_tasks/test_usage_dashboard_sync.py
+++ b/datalad_registry/tests/test_tasks/test_usage_dashboard_sync.py
@@ -62,7 +62,7 @@ import pytest
                             "name": "AIDAqc_datasets/117_m_RT_Vr",
                             "url": "https://gin.g-node.org/AIDAqc_datasets/117_m_RT_Vr",
                             "stars": 0,
-                            "status": "gone"
+                            "status": "active"
                         },
                         {
                             "id": 10158,
@@ -81,7 +81,6 @@ import pytest
             },
             {
                 "https://github.com/1104HARI/fail2ban.git",
-                "https://github.com/314eter/recoll.git",
                 "https://gin.g-node.org/AIDAqc_datasets/117_m_RT_Vr",
             },
         ),

--- a/datalad_registry/tests/test_tasks/test_usage_dashboard_sync.py
+++ b/datalad_registry/tests/test_tasks/test_usage_dashboard_sync.py
@@ -91,7 +91,6 @@ def test_usage_dashboard_sync(
     dashboard_collection: str,
     registered_repos: set[str],
     expected_submitted_repos: set[str],
-    monkeypatch,
 ):
     """
     Test running the Celery task `usage_dashboard_sync`

--- a/datalad_registry/tests/test_tasks/test_usage_dashboard_sync.py
+++ b/datalad_registry/tests/test_tasks/test_usage_dashboard_sync.py
@@ -89,6 +89,95 @@ from datalad_registry.tasks.utils.usage_dashboard import DASHBOARD_COLLECTION_UR
                 "https://gin.g-node.org/AIDAqc_datasets/117_m_RT_Vr",
             },
         ),
+        (
+            """
+                    {
+                        "github": [],
+                        "osf": [],
+                        "gin": []
+                    }""",
+            {
+                "https://github.com/1104HARI/s3cmd.git",
+                "https://gin.g-node.org/AIDAqc_datasets/7_m_RT_Bo",
+                "http://db/example.git",
+            },
+            set(),
+        ),
+        (
+            """
+                {
+                    "github": [
+                        {
+                            "id": 728117155,
+                            "name": "1104HARI/fail2ban",
+                            "url": "https://github.com/1104HARI/fail2ban",
+                            "stars": 0,
+                            "dataset": false,
+                            "run": true,
+                            "container_run": false,
+                            "status": "active"
+                        },
+                        {
+                            "id": 728117263,
+                            "name": "1104HARI/s3cmd",
+                            "url": "https://github.com/1104HARI/s3cmd",
+                            "stars": 0,
+                            "dataset": false,
+                            "run": true,
+                            "container_run": false,
+                            "status": "active"
+                        },
+                        {
+                            "id": 271283042,
+                            "name": "314eter/recoll",
+                            "url": "https://github.com/314eter/recoll",
+                            "stars": 30,
+                            "dataset": false,
+                            "run": true,
+                            "container_run": false,
+                            "status": "gone"
+                        }
+                    ],
+                    "osf": [
+                        {
+                            "url": "https://osf.io/4cdw3/",
+                            "id": "4cdw3",
+                            "name": "3am-complex-orientation-phantoms",
+                            "status": "active"
+                        },
+                        {
+                            "url": "https://osf.io/u5w4j/",
+                            "id": "u5w4j",
+                            "name": "AOMICPIOP2DemoDataset",
+                            "status": "active"
+                        }
+                    ],
+                    "gin": [
+                        {
+                            "id": 10064,
+                            "name": "AIDAqc_datasets/117_m_RT_Vr",
+                            "url": "https://gin.g-node.org/AIDAqc_datasets/117_m_RT_Vr",
+                            "stars": 0,
+                            "status": "active"
+                        },
+                        {
+                            "id": 10158,
+                            "name": "AIDAqc_datasets/7_m_RT_Bo",
+                            "url": "https://gin.g-node.org/AIDAqc_datasets/7_m_RT_Bo",
+                            "stars": 0,
+                            "status": "active"
+                        }
+                    ]
+                }
+                """,
+            set(),
+            {
+                "https://github.com/1104HARI/fail2ban.git",
+                "https://github.com/1104HARI/s3cmd.git",
+                "https://gin.g-node.org/AIDAqc_datasets/117_m_RT_Vr",
+                "https://gin.g-node.org/AIDAqc_datasets/7_m_RT_Bo",
+            },
+        ),
     ],
 )
 @pytest.mark.parametrize("post_resp_status_code", [201, 202, 400])

--- a/datalad_registry_client/submit_urls.py
+++ b/datalad_registry_client/submit_urls.py
@@ -9,7 +9,7 @@ from datalad.support.param import Parameter
 import requests
 from yarl import URL
 
-from datalad_registry.blueprints.api.dataset_urls import DATASET_URLS_PATH
+from datalad_registry.blueprints.api import DATASET_URLS_PATH
 
 from . import DEFAULT_BASE_ENDPOINT
 

--- a/datalad_registry_client/submit_urls.py
+++ b/datalad_registry_client/submit_urls.py
@@ -9,11 +9,9 @@ from datalad.support.param import Parameter
 import requests
 from yarl import URL
 
-from . import DEFAULT_BASE_ENDPOINT
+from datalad_registry.blueprints.api.dataset_urls import DATASET_URLS_PATH
 
-# The path of the dataset URLs resource on the DataLad Registry instance relative to
-# the base API endpoint of the instance.
-_DATASET_URLS_PATH = "dataset-urls"
+from . import DEFAULT_BASE_ENDPOINT
 
 lgr = logging.getLogger("datalad.registry.submit_urls")
 
@@ -50,7 +48,7 @@ class RegistrySubmitURLs(Interface):
                 "datalad_registry.base_endpoint", DEFAULT_BASE_ENDPOINT
             )
 
-        endpoint = URL(base_endpoint) / _DATASET_URLS_PATH
+        endpoint = URL(base_endpoint) / DATASET_URLS_PATH
         endpoint_str = str(endpoint)
 
         res_base = get_status_dict(

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,6 +20,9 @@ services:
       DATALAD_REGISTRY_INSTANCE_PATH: /app/instance
       DATALAD_REGISTRY_DATASET_CACHE: /data/cache
 
+      # URL for any service to reach the web service API
+      DATALAD_REGISTRY_WEB_API_URL: "http://web:5000/api/v2"
+
       CELERY_BROKER_URL: "${CELERY_BROKER_URL}"
       CELERY_RESULT_BACKEND: "redis://backend:6379"
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,3 +12,4 @@ mypy
 types-requests
 beautifulsoup4==4.12.2
 pytest-mock==3.11.1
+responses==0.24.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ tests =
     pytest-cov>=4.0
     beautifulsoup4 ~= 4.12
     pytest-mock ~= 3.0
+    responses ~= 0.24
 
 dev =
     %(tests)s

--- a/tools/populate.py
+++ b/tools/populate.py
@@ -9,12 +9,12 @@ from typing import Optional
 import click
 import requests
 
-from datalad_registry.tasks.utils.usage_dashboard import DashboardCollection, Status
-from datalad_registry_client.submit_urls import RegistrySubmitURLs
-
-DASHBOARD_COLLECTION_URL = (
-    "https://github.com/datalad/datalad-usage-dashboard/raw/master/datalad-repos.json"
+from datalad_registry.tasks.utils.usage_dashboard import (
+    DASHBOARD_COLLECTION_URL,
+    DashboardCollection,
+    Status,
 )
+from datalad_registry_client.submit_urls import RegistrySubmitURLs
 
 
 @click.command()

--- a/tools/populate.py
+++ b/tools/populate.py
@@ -7,57 +7,14 @@
 from typing import Optional
 
 import click
-from pydantic import BaseModel, HttpUrl, StrictBool, StrictInt, StrictStr
 import requests
 
-from datalad_registry.tasks.utils.usage_dashboard import Status
+from datalad_registry.tasks.utils.usage_dashboard import DashboardCollection, Status
 from datalad_registry_client.submit_urls import RegistrySubmitURLs
 
 DASHBOARD_COLLECTION_URL = (
     "https://github.com/datalad/datalad-usage-dashboard/raw/master/datalad-repos.json"
 )
-
-
-class Repo(BaseModel):
-    """
-    Pydantic model for representing a git repo found in datalad-usage-dashboard
-    """
-
-    name: StrictStr
-    url: HttpUrl
-    status: Status
-
-
-class GitHubRepo(Repo):
-    """
-    Pydantic model for representing GitHub repository information found in
-    datalad-usage-dashboard
-    """
-
-    id: Optional[StrictInt]
-    stars: StrictInt
-    dataset: StrictBool
-    run: StrictBool
-    container_run: StrictBool
-
-
-class OSFRepo(Repo):
-    """
-    Pydantic model for representing OSF repository information found in
-    datalad-usage-dashboard
-    """
-
-    id: StrictStr
-
-
-class DashboardCollection(BaseModel):
-    """
-    Pydantic model for representing a collection of git repos found in
-    datalad-usage-dashboard
-    """
-
-    github: list[GitHubRepo]
-    osf: list[OSFRepo]
 
 
 @click.command()

--- a/tools/populate.py
+++ b/tools/populate.py
@@ -46,7 +46,7 @@ def populate(start: Optional[int], stop: Optional[int]) -> None:
 
     # Build clone URLs for active GitHub datasets
     active_github_dataset_urls = list(
-        {ds.url + ".git": None for ds in active_github_datasets}
+        {ds.clone_url: None for ds in active_github_datasets}
     )
 
     # Select URLs of active GitHub datasets to submit

--- a/tools/populate.py
+++ b/tools/populate.py
@@ -4,28 +4,18 @@
 # Note: Currently, this script can only populate the datalad-registry instance with
 #       active datasets on GitHub listed in datalad-usage-dashboard.
 
-from enum import auto
 from typing import Optional
 
 import click
 from pydantic import BaseModel, HttpUrl, StrictBool, StrictInt, StrictStr
 import requests
 
-from datalad_registry.utils import StrEnum
+from datalad_registry.tasks.utils.usage_dashboard import Status
 from datalad_registry_client.submit_urls import RegistrySubmitURLs
 
 DASHBOARD_COLLECTION_URL = (
     "https://github.com/datalad/datalad-usage-dashboard/raw/master/datalad-repos.json"
 )
-
-
-class Status(StrEnum):
-    """
-    Enum for representing the status of repo
-    """
-
-    active = auto()
-    gone = auto()
 
 
 class Repo(BaseModel):

--- a/tools/sync_with_user_dashboard.py
+++ b/tools/sync_with_user_dashboard.py
@@ -2,6 +2,9 @@
 # on demand. Thus, can be used to ensure that the active repositories listed in
 # datalad-usage-dashboard is are registered in datalad-registry on demand.
 
+# Note: This script must be invoked in an environment where the Datalad-Registry
+#       Flask app or Celery app can be initialized.
+
 
 from datalad_registry import create_app
 from datalad_registry.tasks import usage_dashboard_sync

--- a/tools/sync_with_user_dashboard.py
+++ b/tools/sync_with_user_dashboard.py
@@ -1,0 +1,13 @@
+# This script initiates the Celery task, `datalad_registry.tasks.usage_dashboard_sync`
+# on demand. Thus, can be used to ensure that the active repositories listed in
+# datalad-usage-dashboard is are registered in datalad-registry on demand.
+
+
+from datalad_registry import create_app
+from datalad_registry.tasks import usage_dashboard_sync
+
+# Set up the Datalad-Registry Celery app through creating the Datalad-Registry Flask app
+create_app()
+
+# Trigger a `usage_dashboard_sync` task to be executed by a Celery worker
+usage_dashboard_sync.delay()


### PR DESCRIPTION
This PR does the following.

1. Implements a periodic Celery task for ensuring all active repos presented in [datalad-usage-dashboard](https://github.com/datalad/datalad-usage-dashboard) are registered in Datalad-Registry (excepts repos from OSF which will be supported later). This PR closes #271.
2. Provides a script to invoke the above Celery task on demand. Thus, an empty instance of Datalad-Registry can be populated with all the active repos presented in the usage dashboard by running this script. 
3. Refactor some of the Pydantic models used by `tools.populate.py` so that these models can be used by the aforementioned Celery task as well.
4. [`responses`](https://github.com/getsentry/responses) will be added as a dependency for testing for the purpose of mocking out the `requests` library.

Note: Changes of this PR has been applied to the Typhon instance.