### PR TITLE
Rename `operation_mode_to_config_cls` to `OPERATION_MODE_TO_CONFIG_CLS` in conf.py

### DIFF
--- a/datalad_registry/conf.py
+++ b/datalad_registry/conf.py
@@ -119,7 +119,7 @@ class ReadOnlyConfig(BaseConfig):
         return {}
 
 
-operation_mode_to_config_cls = {
+OPERATION_MODE_TO_CONFIG_CLS = {
     OperationMode.PRODUCTION: ProductionConfig,
     OperationMode.DEVELOPMENT: DevelopmentConfig,
     OperationMode.TESTING: TestingConfig,
@@ -134,7 +134,7 @@ def compile_config_from_env() -> BaseConfig:
     """
     operation_mode = OperationConfig().DATALAD_REGISTRY_OPERATION_MODE
 
-    config_cls = operation_mode_to_config_cls.get(operation_mode)
+    config_cls = OPERATION_MODE_TO_CONFIG_CLS.get(operation_mode)
 
     if config_cls is not None:
         return config_cls()

--- a/datalad_registry/tests/test_conf.py
+++ b/datalad_registry/tests/test_conf.py
@@ -302,7 +302,7 @@ class TestCompileConfigFromEnv:
         from datalad_registry import conf
 
         monkeypatch.setattr(
-            conf, "operation_mode_to_config_cls", MockOperationModeToConfigCls()
+            conf, "OPERATION_MODE_TO_CONFIG_CLS", MockOperationModeToConfigCls()
         )
 
         with pytest.raises(ValueError, match="Unexpected operation mode"):


### PR DESCRIPTION
Rename `operation_mode_to_config_cls` to `OPERATION_MODE_TO_CONFIG_CLS` in conf.py. It is more appropriate for the map/dict to be named so since it is a constant.