### PR TITLE
Update the codecov badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/gh/datalad/datalad-registry/branch/master/graph/badge.svg?token=CY783CBF77)](https://codecov.io/gh/datalad/datalad-registry)
+[![codecov](https://codecov.io/gh/datalad/datalad-registry/graph/badge.svg?token=CY783CBF77)](https://codecov.io/gh/datalad/datalad-registry)
 
 DataLad registry -- work in progress
 


### PR DESCRIPTION
The original link shows an "unknown" status.