### PR TITLE
Use Field names instead of aliases in constructing JSON schema for response Pydantic model(s)

### DIFF
--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -241,6 +241,11 @@ class DatasetURLRespModel(DatasetURLRespBaseModel):
         None, alias="metadata_", description="The metadata of the dataset at the URL"
     )
 
+    class Config:
+        # Ensure the JSON schema of the model uses the field name
+        # instead of the alias to name a field
+        by_alias = False
+
 
 class DatasetURLPage(BaseModel):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ celery[redis]==5.3.1
 click==8.1.3
 datalad==0.19.3
 datalad-metalad==0.4.20
-flask-openapi3==2.3.2
+flask-openapi3==2.5.5
 Flask-SQLAlchemy==3.0.5
 SQLAlchemy==2.0.17
 psycopg2==2.9.6


### PR DESCRIPTION
This PR ensures that the JSON schema for a Pydantic model used in a web API response are constructed using the names, instead of the aliases, of the fields in the model.

This PR closes #191.