### PR TITLE
Remove needed use of aliases in Pydantic models

### DIFF
--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -45,7 +45,7 @@ _ORDER_KEY_TO_SQLA_ATTR = {
     OrderKey.annex_key_count: RepoUrl.annex_key_count,
     OrderKey.annexed_files_in_wt_count: RepoUrl.annexed_files_in_wt_count,
     OrderKey.annexed_files_in_wt_size: RepoUrl.annexed_files_in_wt_size,
-    OrderKey.last_update: RepoUrl.last_update_dt,
+    OrderKey.last_update_dt: RepoUrl.last_update_dt,
     OrderKey.git_objects_kb: RepoUrl.git_objects_kb,
 }
 

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -208,7 +208,7 @@ class DatasetURLRespBaseModel(DatasetURLSubmitModel):
     annexed_files_in_wt_size: Optional[int] = Field(
         None, description="The size of annexed files in the working tree in bytes"
     )
-    last_update: Optional[datetime] = Field(
+    last_update_dt: Optional[datetime] = Field(
         None,
         alias="last_update_dt",
         description="The last time the local copy of the dataset was updated",

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -197,7 +197,7 @@ class DatasetURLRespBaseModel(DatasetURLSubmitModel):
 
     id: int = Field(..., description="The ID of the dataset URL")
     ds_id: Optional[UUID] = Field(None, description="The ID, a UUID, of the dataset")
-    describe: Optional[str] = Field(
+    head_describe: Optional[str] = Field(
         None,
         alias="head_describe",
         description="The output of `git describe --tags --always` on the dataset",

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -196,9 +196,7 @@ class DatasetURLRespBaseModel(DatasetURLSubmitModel):
     """
 
     id: int = Field(..., description="The ID of the dataset URL")
-    ds_id: Optional[UUID] = Field(
-        None, alias="ds_id", description="The ID, a UUID, of the dataset"
-    )
+    ds_id: Optional[UUID] = Field(None, description="The ID, a UUID, of the dataset")
     describe: Optional[str] = Field(
         None,
         alias="head_describe",

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -210,7 +210,6 @@ class DatasetURLRespBaseModel(DatasetURLSubmitModel):
     )
     last_update_dt: Optional[datetime] = Field(
         None,
-        alias="last_update_dt",
         description="The last time the local copy of the dataset was updated",
     )
     git_objects_kb: Optional[int] = Field(

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -47,7 +47,7 @@ class OrderKey(StrEnum):
     annex_key_count = auto()
     annexed_files_in_wt_count = auto()
     annexed_files_in_wt_size = auto()
-    last_update = auto()
+    last_update_dt = auto()
     git_objects_kb = auto()
 
 
@@ -161,7 +161,7 @@ class QueryParams(BaseModel):
 
     # Ordering parameters
     order_by: OrderKey = Field(
-        OrderKey.last_update,
+        OrderKey.last_update_dt,
         description="The key to use to order the items in the query",
     )
     order_dir: OrderDir = Field(

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -199,7 +199,6 @@ class DatasetURLRespBaseModel(DatasetURLSubmitModel):
     ds_id: Optional[UUID] = Field(None, description="The ID, a UUID, of the dataset")
     head_describe: Optional[str] = Field(
         None,
-        alias="head_describe",
         description="The output of `git describe --tags --always` on the dataset",
     )
     annex_key_count: Optional[int] = Field(None, description="The number of annex keys")

--- a/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
@@ -232,7 +232,7 @@ class TestDatasetURLs:
             {"order_by": "annex_key_count"},
             {"order_by": "annexed_files_in_wt_count"},
             {"order_by": "annexed_files_in_wt_size"},
-            {"order_by": "last_update"},
+            {"order_by": "last_update_dt"},
             {"order_by": "git_objects_kb"},
             {"order_dir": "asc"},
             {"order_dir": "desc"},
@@ -449,7 +449,7 @@ class TestDatasetURLs:
 
             assert len(pg_lk.query) == 4
             assert pg_lk.query["per_page"] == "2"
-            assert pg_lk.query["order_by"] == "last_update"
+            assert pg_lk.query["order_by"] == "last_update_dt"
             assert pg_lk.query["order_dir"] == "desc"
 
         assert len(ds_url_pg.dataset_urls) == 2
@@ -487,7 +487,7 @@ class TestDatasetURLs:
 
             assert len(pg_lk.query) == 4
             assert pg_lk.query["per_page"] == "2"
-            assert pg_lk.query["order_by"] == "last_update"
+            assert pg_lk.query["order_by"] == "last_update_dt"
             assert pg_lk.query["order_dir"] == "desc"
 
         assert len(ds_url_pg.dataset_urls) == 2


### PR DESCRIPTION
This PR renames some fields in the models used in web API responses so that the names are consistent with the models used for accessing the database. In this process, the alias of these renamed fields are eliminated because they are no longer necessary.