### PR TITLE
Do provide secret token for CODECOV

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,3 +57,6 @@ jobs:
       run: mypy datalad_registry datalad_registry_client
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,5 @@ jobs:
       run: mypy datalad_registry datalad_registry_client
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v4
-      with:
-        fail_ci_if_error: false
-        token: ${{ secrets.CODECOV_TOKEN }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
It is needed for v4 -- we added that secret at the level of the organization so should be available