### PR TITLE
Configure the web UI so that the 'Nr of Annexed files' and 'Size of Annexed files' headers occupy different columns

### DIFF
--- a/datalad_registry/static/main.css
+++ b/datalad_registry/static/main.css
@@ -64,7 +64,6 @@ div#datalad-registry div.pagination {
 
 .tooltip {
     position: relative;
-    display: inline-block;
     border-bottom: 1px dotted black;
 }
 


### PR DESCRIPTION
This PR configure the web UI so that the 'Nr of Annexed files' and 'Size of Annexed files' headers occupy different columns. 

This closes #302 which is due to table cells not being able to align to table headers.