### PR TITLE
Increase the interval between savings of `Flower`'s state

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -85,7 +85,7 @@ services:
       FLOWER_BROKER_API: "${FLOWER_BROKER_API}"
       FLOWER_PERSISTENT: "True"
       FLOWER_DB: "/data/flower"
-      FLOWER_STATE_SAVE_INTERVAL: "60000"  # 1 minutes (in milliseconds)
+      FLOWER_STATE_SAVE_INTERVAL: "60000"  # 1 minute (in milliseconds)
       FLOWER_NATURAL_TIME: "True"
       FLOWER_BASIC_AUTH: "$FLOWER_BASIC_AUTH"
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -85,7 +85,7 @@ services:
       FLOWER_BROKER_API: "${FLOWER_BROKER_API}"
       FLOWER_PERSISTENT: "True"
       FLOWER_DB: "/data/flower"
-      FLOWER_STATE_SAVE_INTERVAL: "1000"  # In milliseconds
+      FLOWER_STATE_SAVE_INTERVAL: "60000"  # 1 minutes (in milliseconds)
       FLOWER_NATURAL_TIME: "True"
       FLOWER_BASIC_AUTH: "$FLOWER_BASIC_AUTH"
     ports:


### PR DESCRIPTION
This PR increases the time interval between savings of Flower's state. Each saving of Flower's state causes a complete re-write of the [DB](https://flower.readthedocs.io/en/latest/config.html#db) for storing Flower's state, so this interval must be sufficiently large to avoid overworking the CPU and the storage hardware.

This PR closes #258 and #301.

Note: Once this PR is merged. We need to switch the directory containing the DB file, `flower`, back to a spindle hard drive. 