### PR TITLE
Pin Postgres version

### DIFF
--- a/docker-compose.read-only.yml
+++ b/docker-compose.read-only.yml
@@ -24,7 +24,7 @@ services:
       - ${WEB_PATH_AT_HOST}/instance:/app/instance
 
   read-only-db:
-    image: docker.io/postgres:latest
+    image: docker.io/postgres:15
     environment:
       POSTGRES_DB: "${POSTGRES_DB}"
       POSTGRES_USER: "${POSTGRES_USER}"

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -26,7 +26,7 @@ services:
       - "127.0.0.1:6379:6379"
 
   db:
-    image: docker.io/postgres:latest
+    image: docker.io/postgres:15
     environment:
       POSTGRES_DB: "${POSTGRES_DB}"
       POSTGRES_USER: "${POSTGRES_USER}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       - "127.0.0.1:6379:6379"
 
   db:
-    image: docker.io/postgres:latest
+    image: docker.io/postgres:15
     environment:
       POSTGRES_DB: "${POSTGRES_DB}"
       POSTGRES_USER: "${POSTGRES_USER}"


### PR DESCRIPTION
This PR pins the version of Postgres to be used to version 15.

To sync the primary and read-only instances of Datalad-Registry, their Postgres DB services have to be in the same version. Pinning the Docker image of Postgres to be used in different Docker Compose files will help ensure that the same version of Postgres to be used across different instances of Datalad-Registry. Since our current live instances of Datalad-Registry have Postgres at version 15, version 15 is picked.


Note: To get the relevant commits of this PR, merge the master branch to this branch after #306 is merged to the master.

