### PR TITLE
Handle `NULL` column values correctly in `ilike` queries

### DIFF
--- a/datalad_registry/search.py
+++ b/datalad_registry/search.py
@@ -154,7 +154,9 @@ class SearchQueryTransformer(Transformer):
         else:  # was more than one
             assert isinstance(metadata_extractors_l, Tree)
             assert metadata_extractors_l.data.value == "metadata_extractors"  # type: ignore
-            extractors = list(map(self._get_str_value, metadata_extractors_l.children))  # type: ignore
+            extractors = list(
+                map(self._get_str_value, metadata_extractors_l.children)  # type: ignore
+            )
         if not extractors:
             raise ValueError(f"No extractors were specified in {metadata_extractors_l}")
         # TODO: might want to provide a dedicated simpler one


### PR DESCRIPTION
This PR addresses the issue describe in https://github.com/datalad/datalad-registry/pull/308#issuecomment-1961967932. The changes in this PR passes the tests describe in the issue. However, it causes some failures in other tests. I am unable to resolve the new failures at this point because they seems to be related to lark.

The rationale behind this fix as explained by ChatGPT.

> 
> You're correct in pointing out a misconception in my previous explanation regarding the evaluation of conditions involving `NULL` values in SQL. Let's clarify the behavior, especially in the context of your question about the behavior of `NULL` with `ILIKE` and logical operators.
> 
> In SQL, when you evaluate an expression involving `NULL` with a comparison operator (such as `=`, `!=`, `<`, `>`, `LIKE`, `ILIKE`, etc.), the result is `NULL`, which represents an unknown value. However, the logical treatment of `NULL` in conditional expressions like `WHERE` clauses behaves a bit differently when combined with logical operators (`AND`, `OR`, `NOT`).
> 
> ### The Correct Behavior
> 
> When you use an expression like:
> 
> ```sql
> (repo_url.url NOT ILIKE '%handbook%' OR repo_url.url IS NULL)
> ```
> 
> The evaluation logic works as follows:
> 
> - **`repo_url.url NOT ILIKE '%handbook%'`**: If `repo_url.url` is `NULL`, this condition evaluates to `NULL` because the result of any comparison with `NULL` is unknown (`NULL`).
> 
> - **`repo_url.url IS NULL`**: This explicitly checks for `NULL` and evaluates to `true` if `repo_url.url` is indeed `NULL`.
> 
> When combined with `OR`:
> 
> - If `repo_url.url` is `NULL`, the left side of the `OR` (`repo_url.url NOT ILIKE '%handbook%'`) evaluates to `NULL`, but the right side (`repo_url.url IS NULL`) evaluates to `true`. Since `NULL OR true` is `true` in SQL's logical operations, the overall condition will evaluate to `true`, thus including the row in the results.
> 
> In contrast to my incorrect implication before, the presence of `OR repo_url.url IS NULL` ensures that rows where `repo_url.url` is `NULL` are indeed considered and not excluded based on the `ILIKE` comparison alone. The logical `OR` ensures that if either condition is `true` (or in SQL terms, if either side evaluates to `true` or `NULL` and the other to `true`), the overall expression is considered `true`.
> 
> So, for a row where `repo_url.url` is `NULL`, the evaluation of `(repo_url.url NOT ILIKE '%handbook%' OR repo_url.url IS NULL)` effectively becomes `true`, ensuring such rows are included in the query results, contrary to the concern of it evaluating to `NULL` and being excluded.
> 
> I appreciate your patience and the opportunity to correct this explanation. Your understanding of the behavior of `NULL` in SQL is indeed correct, and it's an important aspect of SQL query formulation to grasp.

Additionally,

> **In conditional expressions**, such as those in `WHERE` clauses, a condition that evaluates to `NULL` does not qualify a row for inclusion in the result set. This is because SQL requires conditions to be explicitly `true` to include a row, and `NULL` is considered neither `true` nor `false`.