### PR TITLE
Expose search functionality in API

### DIFF
--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -8,9 +8,8 @@ from celery import group
 from flask import current_app, url_for
 from flask_openapi3 import APIBlueprint, Tag
 from psycopg2.errors import UniqueViolation
-from sqlalchemy import and_
+from sqlalchemy import ColumnElement, and_
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.sql.elements import BinaryExpression
 
 from datalad_registry.models import RepoUrl, db
 from datalad_registry.tasks import (
@@ -213,7 +212,7 @@ def dataset_urls(query: QueryParams):
 
     # ==== Gathering constraints from query parameters ====
 
-    constraints: list[BinaryExpression] = []
+    constraints: list[ColumnElement] = []
 
     append_constrain_arg_lst = [
         (RepoUrl.url, operator.eq, query.url, str),

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -183,18 +183,20 @@ def dataset_urls(query: QueryParams):
     Get all dataset URLs that satisfy the constraints imposed by the query parameters.
     """
 
-    def append_constraint(
+    def append_column_constraint(
         db_model_column, op, qry, qry_spec_transform=(lambda x: x)
     ) -> None:
         """
         Append a filter constraint corresponding to a given query parameter value
+        meant for constraining the value of a column of a SQLAlchemy model
         to the list of filter constraints.
 
-        :param db_model_column: The SQLAlchemy model column to build the constraint with
+        :param db_model_column: The SQLAlchemy model column of which its value to be
+                                constrained
         :param op: The operator to build the constraint with
         :param qry: The query parameter value
         :param qry_spec_transform: The transformation to apply to the query parameter
-                                   value in to build the constraint. Defaults to the
+                                   value to build the constraint. Defaults to the
                                    identity function.
         """
         if qry is not None:
@@ -214,7 +216,7 @@ def dataset_urls(query: QueryParams):
 
     constraints: list[ColumnElement] = []
 
-    append_constrain_arg_lst = [
+    append_column_constraint_arg_lst = [
         (RepoUrl.url, operator.eq, query.url, str),
         (RepoUrl.ds_id, operator.eq, query.ds_id, str),
         (RepoUrl.annex_key_count, operator.ge, query.min_annex_key_count),
@@ -247,8 +249,8 @@ def dataset_urls(query: QueryParams):
         (RepoUrl.cache_path, operator.eq, query.cache_path, cache_path_trans),
     ]
 
-    for args in append_constrain_arg_lst:
-        append_constraint(*args)
+    for args in append_column_constraint_arg_lst:
+        append_column_constraint(*args)
 
     # ==== Gathering constraints from query parameters ends ====
 

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -75,6 +75,14 @@ class QueryParams(BaseModel):
     the dataset_urls endpoint
     """
 
+    search: Optional[str] = Field(
+        None,
+        description="A search string used to perform a search identical to the one "
+        "offered by the Web UI. Please consult the Web UI for the expected "
+        "syntax of this search string by clicking on "
+        'the "Show Search Query Syntax" button.',
+    )
+
     url: Optional[Union[FileUrl, AnyUrl, Path]] = Field(None, description="The URL")
 
     ds_id: Optional[UUID] = Field(None, description="The ID, a UUID, of the dataset")

--- a/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
@@ -354,6 +354,28 @@ class TestDatasetURLs:
                 {"cache_path": "a/b/c"},
                 {"https://www.dandiarchive.org"},
             ),
+            # === filtered by search ===
+            (
+                {"search": "Handbook"},
+                {"https://handbook.datalad.org"},
+            ),
+            (
+                {"search": "ds_id:be3132291d7b"},
+                {"https://www.example.com"},
+            ),
+            (
+                {"search": "ds_id:be3132291d7c OR dandiarchive"},
+                {"http://www.datalad.org", "https://www.dandiarchive.org"},
+            ),
+            # === filtered by search and other query params ===
+            (
+                {"search": "ds_id:2a0b7b7b", "min_annex_key_count": "39"},
+                {"http://www.datalad.org", "https://handbook.datalad.org"},
+            ),
+            (
+                {"search": "url:.org", "max_annexed_files_in_wt_size": 401},
+                {"http://www.datalad.org"},
+            ),
         ],
     )
     def test_filter(self, flask_client, query_params, expected_output):

--- a/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
@@ -396,6 +396,23 @@ class TestDatasetURLs:
         # Check the collection of dataset URLs
         assert {i.url for i in ds_url_page.dataset_urls} == expected_output
 
+    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.parametrize(
+        "query_params",
+        [
+            {"search": "unknown_field:example"},
+            {"search": "url:example OR no_body:knows"},
+            {"url": "https://www.example.com", "search": "never:encountered"},
+        ],
+    )
+    def test_filter_with_invalid_search_query_param(self, query_params, flask_client):
+        """
+        Test filtering with a search query parameter with invalid grammar/syntax
+        """
+        resp = flask_client.get("/api/v2/dataset-urls", query_string=query_params)
+        assert resp.status_code == 400
+        assert "Grammar" in resp.json["description"]
+
     @pytest.mark.usefixtures("populate_with_url_metadata")
     @pytest.mark.parametrize(
         "metadata_ret_opt",


### PR DESCRIPTION
This PR exposes the search functionality available in the web UI through the API. It closes #269.

The search functionality is exposed via the query parameter `search` to the existing collection endpoint of `/api/v2/dataset-urls`. This parameter can be mix with other parameters at that endpoint to create more restricted searchs.

Note: The changes in this PR has been applied to the live instances of DL-Registry.