### PR TITLE
Fix the link for the last page of pagination in API

### DIFF
--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -271,7 +271,7 @@ def dataset_urls(query: QueryParams):
     )
     orm_ds_urls = pagination.items
     cur_pg_num = pagination.page
-    last_pg_num = pagination.pages
+    total_pages = pagination.pages  # Total number of pages
 
     if query.return_metadata is None:
         # === No metadata should be returned ===
@@ -321,7 +321,7 @@ def dataset_urls(query: QueryParams):
         if pagination.has_next
         else None,
         first_pg=url_for(ep, **base_qry, page=1),
-        last_pg=url_for(ep, **base_qry, page=last_pg_num),
+        last_pg=url_for(ep, **base_qry, page=1 if total_pages == 0 else total_pages),
         dataset_urls=ds_urls,
     )
 

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -19,6 +19,9 @@ from datalad_registry.utils import StrEnum
 
 from ..url_metadata.models import URLMetadataModel, URLMetadataRef
 
+DEFAULT_PAGE = 1  # Default page query param value
+DEFAULT_PER_PAGE = 20  # Default per_page query param value
+
 
 def path_url_must_be_absolute(url):
     """
@@ -149,14 +152,15 @@ class QueryParams(BaseModel):
 
     # Pagination parameters
     page: PositiveInt = Field(
-        1,
+        DEFAULT_PAGE,
         description="The current page (used to calculate the offset "
-        "of the pagination). Defaults to 1.",
+        f"of the pagination). Defaults to {DEFAULT_PAGE}.",
     )
     per_page: PositiveInt = Field(
-        20,
+        DEFAULT_PER_PAGE,
         description="The maximum number of items on a page "
-        "(used to calculate the offset and limit of the pagination). Defaults to 20.",
+        "(used to calculate the offset and limit of the pagination). "
+        f"Defaults to {DEFAULT_PER_PAGE}.",
     )
 
     # Ordering parameters


### PR DESCRIPTION
This PR corrects the generation of the link of the last page in a paginated result. Specifically, when a paginated result contains no item, i.e. having 0 page in return, the correct last page should be 1 instead of 0.

Additionally, a related test is also updated in this PR to verify the related behavior.