### PR TITLE
Prevent automatic syncing with datalad-usage-dashboard

### DIFF
--- a/docker-compose.dev.override.yml
+++ b/docker-compose.dev.override.yml
@@ -4,6 +4,10 @@
 
 services:
   web:
+    environment: &env
+      # To prevent syncing with the usage dashboard in development
+      # Set sync cycle to 100 years (in seconds)
+      DATALAD_REGISTRY_USAGE_DASHBOARD_SYNC_CYCLE_LENGTH: "3153600000.0"
     command: [
       "/sbin/my_init", "--",
       "bash", "-c",
@@ -13,8 +17,14 @@ services:
       - ./:/app
       - ./instance:/app/instance
 
+  worker:
+    environment:
+      <<: *env
+
   scheduler:
     environment:
-      # To prevent syncing with the usage dashboard in development
-      # Set sync cycle to 100 years (in seconds)
-      DATALAD_REGISTRY_USAGE_DASHBOARD_SYNC_CYCLE_LENGTH: "3153600000.0"
+      <<: *env
+
+  monitor:
+    environment:
+      <<: *env

--- a/docker-compose.dev.override.yml
+++ b/docker-compose.dev.override.yml
@@ -12,3 +12,9 @@ services:
     volumes:
       - ./:/app
       - ./instance:/app/instance
+
+  scheduler:
+    environment:
+      # To prevent syncing with the usage dashboard in development
+      # Set sync cycle to 100 years (in seconds)
+      DATALAD_REGISTRY_USAGE_DASHBOARD_SYNC_CYCLE_LENGTH: "3153600000.0"


### PR DESCRIPTION
This PR prevents a Datalad-Registry instance used for development to sync automatically with [datalad-usage-dashboard](https://github.com/datalad/datalad-usage-dashboard).