### PR TITLE
Upgrade `versioningit` dependency used by the build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 46.4.0", "versioningit ~= 0.1", "wheel ~= 0.32"]
+requires = ["setuptools >= 46.4.0", "versioningit ~= 3.0", "wheel ~= 0.32"]
 build-backend = "setuptools.build_meta"
 
 [tool.versioningit]


### PR DESCRIPTION
Upgrade to the latest compatible versions starting at 3.0.0