### PR TITLE
Remove the use of `importlib_metadata`

### DIFF
--- a/datalad_registry/__init__.py
+++ b/datalad_registry/__init__.py
@@ -1,5 +1,5 @@
+from importlib.metadata import version
 from pathlib import Path
-import sys
 
 from celery import Celery, Task
 from flask import Flask, request
@@ -11,11 +11,6 @@ from . import overview, root
 from .conf import OperationMode, compile_config_from_env
 from .models import db, init_db_command, migrate
 from .utils.pydantic_json import pydantic_dumps, pydantic_loads
-
-if sys.version_info[:2] < (3, 8):
-    from importlib_metadata import version
-else:
-    from importlib.metadata import version
 
 __version__ = version("datalad-registry")
 

--- a/datalad_registry_client/__init__.py
+++ b/datalad_registry_client/__init__.py
@@ -1,4 +1,4 @@
-import sys
+from importlib.metadata import version
 
 # The default base API endpoint of the DataLad Registry instance
 # that the client interacts with.
@@ -21,10 +21,5 @@ command_suite = (
         ),
     ],
 )
-
-if sys.version_info[:2] < (3, 8):
-    from importlib_metadata import version
-else:
-    from importlib.metadata import version
 
 __version__ = version("datalad-registry")


### PR DESCRIPTION
The supported version of Python in this project is >= `3.9`, so `importlib.metadata` is available through stdlib