### PR TITLE
Restrict inputs to `search.parse_query` to non-empty strings

### DIFF
--- a/datalad_registry/search.py
+++ b/datalad_registry/search.py
@@ -258,14 +258,19 @@ class SearchQueryTransformer(Transformer):
 def parse_query(query: str) -> ColumnElement[bool]:
     """Parse the search query and return the SQLAlchemy expression.
 
-    :param query: The search query string
+    :param query: The search query string (must not be empty)
 
     :return: The SQLAlchemy expression representing the search query
+
+    :raises ValueError: If `query` is an empty string
 
     A workaround necessary for using "earley" parser.
     We have to use "earley" parser to support ':op' comparison operations.
     Operates using the global parser and transformer objects.
     """
+    if query == "":
+        raise ValueError("Query string cannot be empty")
+
     # Parse the input to get a tree
     parse_tree = parser.parse(query)
     return transformer.transform(parse_tree)

--- a/datalad_registry/tests/test_search.py
+++ b/datalad_registry/tests/test_search.py
@@ -64,6 +64,7 @@ def populate_with_url_metadata_for_search(
         # r'(haxby or halchenko) AND '
         # r'metadata:BIDSmetadata[bids_dataset,metalad_core]:'
         # r'"BIDSVersion\": \"v"',
+        ("", ValueError, "Query string cannot be empty"),
     ],
 )
 def test_with_invalid_query(query, exc, err):


### PR DESCRIPTION
This PR restricts inputs to `search.parse_query` to non-empty strings. An empty query string as an input to the parser will result in `lark.exceptions.UnexpectedEOF` anyway. It is more explicit and informative to rule out this input in the `parse_query` function level.
