### PR TITLE
Limit arg in `search.parse_query` to non-white space only str

### DIFF
--- a/datalad_registry/search.py
+++ b/datalad_registry/search.py
@@ -263,6 +263,7 @@ def parse_query(query: str) -> ColumnElement[bool]:
     :return: The SQLAlchemy expression representing the search query
 
     :raises ValueError: If `query` is an empty string
+    :raises ValueError: If `query` contains only whitespace
 
     A workaround necessary for using "earley" parser.
     We have to use "earley" parser to support ':op' comparison operations.
@@ -270,6 +271,9 @@ def parse_query(query: str) -> ColumnElement[bool]:
     """
     if query == "":
         raise ValueError("Query string cannot be empty")
+
+    if query.isspace():
+        raise ValueError("Query string cannot contain only whitespace")
 
     # Parse the input to get a tree
     parse_tree = parser.parse(query)

--- a/datalad_registry/tests/test_search.py
+++ b/datalad_registry/tests/test_search.py
@@ -65,6 +65,8 @@ def populate_with_url_metadata_for_search(
         # r'metadata:BIDSmetadata[bids_dataset,metalad_core]:'
         # r'"BIDSVersion\": \"v"',
         ("", ValueError, "Query string cannot be empty"),
+        (" ", ValueError, "Query string cannot contain only whitespace"),
+        ("  \t \n", ValueError, "Query string cannot contain only whitespace"),
     ],
 )
 def test_with_invalid_query(query, exc, err):


### PR DESCRIPTION
This PR restricts inputs to `search.parse_query` to strings that doesn't contain only whitespace characters. An string containing only whitespace as an input to the parser will result in lark.exceptions.UnexpectedEOF anyway. It is more explicit and informative to rule out this input in the parse_query function level.

This PR is similar to #344.