### PR TITLE
Handle empty search query string in web UI

### DIFF
--- a/datalad_registry/overview.py
+++ b/datalad_registry/overview.py
@@ -39,7 +39,7 @@ def overview():  # No type hints due to mypy#7187.
     # as we would add search to individual files.
     query = request.args.get("query", None, type=str)
     search_error = None
-    if query:
+    if query is not None:
         lgr.debug("Search by '%s'", query)
         try:
             criteria = parse_query(query)

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -41,7 +41,7 @@
   <div class="content">
     <form action="{{ url_for('.overview') }}" method="get">
       <label for='search' class="sr-only">Search</label>
-      <input id='search' type='search' name='query'
+      <input id='search' type='search' name='query' required pattern=".*\S.*"
           {%- if search_query %} value="{{ search_query|escape }}"
           {%- endif -%}
              placeholder='Search query'

--- a/datalad_registry/tests/test_overview.py
+++ b/datalad_registry/tests/test_overview.py
@@ -182,12 +182,19 @@ class TestOverView:
 
     @pytest.mark.usefixtures("populate_with_dataset_urls")
     @pytest.mark.parametrize(
-        "search_query",
+        "search_query, err_msg_prefix",
         [
-            "unknown_field:example",
+            ("unknown_field:example", "Unknown field: 'unknown_field'. Known are:"),
+            ("", "Query string cannot be empty"),
+            ("  \t \n", "Query string cannot contain only whitespace"),
+            (" ", "Query string cannot contain only whitespace"),
+            ("     ", "Query string cannot contain only whitespace"),
+            ("  \t \n \t   ", "Query string cannot contain only whitespace"),
         ],
     )
-    def test_search_with_invalid_query(self, search_query: Optional[str], flask_client):
+    def test_search_with_invalid_query(
+        self, search_query: str, err_msg_prefix: str, flask_client
+    ):
         """
         Test searching with an invalid query
         """
@@ -197,9 +204,7 @@ class TestOverView:
         soup = BeautifulSoup(resp.text, "html.parser")
 
         assert (error_span := soup.find("span", class_="error"))
-        assert error_span.text.startswith(
-            "ERROR: Unknown field: 'unknown_field'. Known are:"
-        )
+        assert error_span.text.startswith(f"ERROR: {err_msg_prefix}")
 
     def test_pagination(self, populate_with_dataset_urls, flask_client):
         """


### PR DESCRIPTION
The main purpose of this PR is to remove the conflation of the case in which the search query string is not provided and the case in which the search query string is an empty string. Removing this conflation will help to develop will permit better consistency and flexibility and make the intent more clear across the app.

Per ChatGPT:

> The pattern `if query:` in the context of checking if a request parameter (`query` in this case) is provided and non-empty is common in web development. This approach effectively treats a missing parameter (`None`) and an empty string (`""`) the same way, which simplifies handling request parameters that are expected to be non-empty strings when provided.
> 
> This practice can be considered good or bad depending on the specific requirements of your application:
> 
> ### Pros
> 
> 1. **Simplicity**: It simplifies the code by reducing the need for explicit checks for both `None` and empty strings.
> 2. **Usability**: From a user's perspective, an empty string often implies "no input" or "default behavior," so this approach aligns with typical user expectations.
> 3. **Error Prevention**: Automatically filtering out empty strings can prevent errors or unnecessary processing later in your code, where a non-empty string might be assumed.
> 
> ### Cons
> 
> 1. **Potential Inconsistency**: If different parts of your program or different endpoints treat empty strings differently (e.g., sometimes as valid input), it might lead to inconsistencies in how input is handled.
> 2. **Reduced Flexibility**: Automatically treating empty strings as `None` can reduce flexibility. There might be cases where you want to distinguish between a parameter being absent and it being intentionally set to an empty value.
> 3. **Implicit Behavior**: This pattern can sometimes obscure the intent of the code, making it less clear to others (or your future self) that empty strings are being treated as no input.

Additionally, this PR limits user input for the search string to be non-empty strings that contain more than just whitespace chars to ensure user expectations regarding in that aspect are met.

Note: This PR is related to #344 and #345 and will be consistent with https://github.com/datalad/datalad-registry/pull/343 in handling string query arguments.