### PR TITLE
Provide stats about return collection

### DIFF
--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -285,11 +285,11 @@ def dataset_urls(query: QueryParams):
     ep = ".dataset_urls"  # Endpoint of `dataset_urls`
     base_qry = loads(query.json(exclude={"page"}, exclude_none=True))
 
-    base_select = select(RepoUrl).filter(and_(True, *constraints))
+    base_select_stmt = select(RepoUrl).filter(and_(True, *constraints))
 
     max_per_page = 100  # The overriding limit to `per_page` provided by the requester
     pagination = db.paginate(
-        base_select.order_by(
+        base_select_stmt.order_by(
             getattr(
                 _ORDER_KEY_TO_SQLA_ATTR[query.order_by], query.order_dir.value
             )().nulls_last()

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -9,7 +9,7 @@ from flask import abort, current_app, url_for
 from flask_openapi3 import APIBlueprint, Tag
 from lark.exceptions import GrammarError, UnexpectedInput
 from psycopg2.errors import UniqueViolation
-from sqlalchemy import ColumnElement, and_
+from sqlalchemy import ColumnElement, and_, select
 from sqlalchemy.exc import IntegrityError
 
 from datalad_registry.models import RepoUrl, db
@@ -92,7 +92,7 @@ def declare_dataset_url(body: DatasetURLSubmitModel):
     url_as_str = str(body.url)
 
     repo_url_row = db.session.execute(
-        db.select(RepoUrl).filter_by(url=url_as_str)
+        select(RepoUrl).filter_by(url=url_as_str)
     ).one_or_none()
     if repo_url_row is None:
         # == The URL requested to be created does not exist in the database ==
@@ -116,7 +116,7 @@ def declare_dataset_url(body: DatasetURLSubmitModel):
                     # of the URL in the database
                     db.session.rollback()
                     repo_url_added_by_another = (
-                        db.session.execute(db.select(RepoUrl).filter_by(url=url_as_str))
+                        db.session.execute(select(RepoUrl).filter_by(url=url_as_str))
                         .scalars()
                         .one_or_none()
                     )
@@ -285,7 +285,7 @@ def dataset_urls(query: QueryParams):
     ep = ".dataset_urls"  # Endpoint of `dataset_urls`
     base_qry = loads(query.json(exclude={"page"}, exclude_none=True))
 
-    base_select = db.select(RepoUrl).filter(and_(True, *constraints))
+    base_select = select(RepoUrl).filter(and_(True, *constraints))
 
     max_per_page = 100  # The overriding limit to `per_page` provided by the requester
     pagination = db.paginate(

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -9,7 +9,7 @@ from flask import abort, current_app, url_for
 from flask_openapi3 import APIBlueprint, Tag
 from lark.exceptions import GrammarError, UnexpectedInput
 from psycopg2.errors import UniqueViolation
-from sqlalchemy import ColumnElement, Select, and_, select
+from sqlalchemy import ColumnElement, and_, select
 from sqlalchemy.exc import IntegrityError
 
 from datalad_registry.models import RepoUrl, db
@@ -23,7 +23,6 @@ from datalad_registry.tasks import (
 from datalad_registry.utils.flask_tools import json_resp_from_str
 
 from .models import (
-    CollectionStats,
     DatasetURLPage,
     DatasetURLRespBaseModel,
     DatasetURLRespModel,
@@ -33,6 +32,7 @@ from .models import (
     PathParams,
     QueryParams,
 )
+from .tools import get_collection_stats
 from .. import (
     API_URL_PREFIX,
     COMMON_API_RESPONSES,
@@ -178,19 +178,6 @@ def declare_dataset_url(body: DatasetURLSubmitModel):
             mark_for_chk.delay(repo_url.id)
 
         return json_resp_from_str(resp_model, status=202)
-
-
-def get_collection_stats(select_stmt: Select) -> CollectionStats:
-    """
-    Get the statistics of the collection of dataset URLs specified by the given select
-    statement
-
-    :param select_stmt: The given select statement
-    :return: The statistics of the collection of dataset URLs
-
-    Note: The execution of this function requires the Flask app's context
-    """
-    pass
 
 
 @bp.get("", responses={"200": DatasetURLPage, "400": HTTPExceptionResp})

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -285,11 +285,11 @@ def dataset_urls(query: QueryParams):
     ep = ".dataset_urls"  # Endpoint of `dataset_urls`
     base_qry = loads(query.json(exclude={"page"}, exclude_none=True))
 
+    base_select = db.select(RepoUrl).filter(and_(True, *constraints))
+
     max_per_page = 100  # The overriding limit to `per_page` provided by the requester
     pagination = db.paginate(
-        db.select(RepoUrl)
-        .filter(and_(True, *constraints))
-        .order_by(
+        base_select.order_by(
             getattr(
                 _ORDER_KEY_TO_SQLA_ATTR[query.order_by], query.order_dir.value
             )().nulls_last()

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -187,6 +187,8 @@ def get_collection_stats(select_stmt: Select) -> CollectionStats:
 
     :param select_stmt: The given select statement
     :return: The statistics of the collection of dataset URLs
+
+    Note: The execution of this function requires the Flask app's context
     """
     pass
 

--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -342,7 +342,6 @@ def dataset_urls(query: QueryParams):
     assert pagination.total is not None
 
     page = DatasetURLPage(
-        total=pagination.total,
         cur_pg_num=cur_pg_num,
         prev_pg=(
             url_for(ep, **base_qry, page=pagination.prev_num)

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -285,7 +285,7 @@ class DataladDsCollectionStats(BaseModel):
     )
 
 
-class NonAnnexDsStats(BaseModel):
+class NonAnnexDsCollectionStats(BaseModel):
     pass
 
 
@@ -302,7 +302,7 @@ class CollectionStats(BaseModel):
         description="Statistics for pure annex datasets, as individual repos, "
         "without any deduplication"
     )
-    non_annex_ds_stats: NonAnnexDsStats = Field(
+    non_annex_ds_stats: NonAnnexDsCollectionStats = Field(
         description="Statistics for non-annex datasets"
     )
 

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -9,6 +9,7 @@ from pydantic import (
     BaseModel,
     Field,
     FileUrl,
+    NonNegativeInt,
     PositiveInt,
     StrictInt,
     StrictStr,
@@ -256,8 +257,52 @@ class DatasetURLRespModel(DatasetURLRespBaseModel):
         by_alias = False
 
 
-class CollectionStats(BaseModel):
+class _AnnexDsCollectionStats(BaseModel):
+    """
+    Model with the base components of annex dataset collection statistics
+    """
+
+    ds_count: NonNegativeInt = Field(description="The number of datasets")
+    size_of_annexed_files: NonNegativeInt = Field(
+        description="The size of annexed files"
+    )
+    annexed_file_count: NonNegativeInt = Field(
+        description="The number of annexed files"
+    )
+
+
+class AnnexDsCollectionStats(BaseModel):
+    """
+    Model for annex dataset collection statistics
+    """
+
+    unique_ds_stats: _AnnexDsCollectionStats = Field(
+        description="Statistics for unique datasets"
+    )
+    stats: _AnnexDsCollectionStats = Field(description="Statistics for all datasets")
+
+
+class NonAnnexDsStats(BaseModel):
     pass
+
+
+class StatsSummary(BaseModel):
+    unique_ds_count: NonNegativeInt = Field(description="The number of unique datasets")
+    ds_count: NonNegativeInt = Field(description="The number of datasets")
+
+
+class CollectionStats(BaseModel):
+    datalad_ds_stats: AnnexDsCollectionStats = Field(
+        description="Statistics for DataLad datasets"
+    )
+    pure_annex_ds_stats: AnnexDsCollectionStats = Field(
+        description="Statistics for pure annex datasets"
+    )
+    non_annex_ds_stats: NonAnnexDsStats = Field(
+        description="Statistics for non-annex datasets"
+    )
+
+    summary: StatsSummary = Field(description="Summary statistics")
 
 
 class DatasetURLPage(BaseModel):

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -286,7 +286,14 @@ class DataladDsCollectionStats(BaseModel):
 
 
 class NonAnnexDsCollectionStats(BaseModel):
-    pass
+    """
+    Model for non-annex dataset collection statistics
+    """
+
+    ds_count: NonNegativeInt = Field(
+        description="The number of datasets, as individual repos, "
+        "without any deduplication"
+    )
 
 
 class StatsSummary(BaseModel):

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -279,7 +279,10 @@ class DataladDsCollectionStats(BaseModel):
     unique_ds_stats: AnnexDsCollectionStats = Field(
         description="Statistics for unique datasets"
     )
-    stats: AnnexDsCollectionStats = Field(description="Statistics for all datasets")
+    stats: AnnexDsCollectionStats = Field(
+        description="Statistics for all datasets, as individual repos, "
+        "without any deduplication"
+    )
 
 
 class NonAnnexDsStats(BaseModel):

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -257,7 +257,7 @@ class DatasetURLRespModel(DatasetURLRespBaseModel):
         by_alias = False
 
 
-class _AnnexDsCollectionStats(BaseModel):
+class AnnexDsCollectionStats(BaseModel):
     """
     Model with the base components of annex dataset collection statistics
     """
@@ -276,10 +276,10 @@ class DataladDsCollectionStats(BaseModel):
     Model for DataLad dataset collection statistics
     """
 
-    unique_ds_stats: _AnnexDsCollectionStats = Field(
+    unique_ds_stats: AnnexDsCollectionStats = Field(
         description="Statistics for unique datasets"
     )
-    stats: _AnnexDsCollectionStats = Field(description="Statistics for all datasets")
+    stats: AnnexDsCollectionStats = Field(description="Statistics for all datasets")
 
 
 class NonAnnexDsStats(BaseModel):

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -291,7 +291,10 @@ class NonAnnexDsCollectionStats(BaseModel):
 
 class StatsSummary(BaseModel):
     unique_ds_count: NonNegativeInt = Field(description="The number of unique datasets")
-    ds_count: NonNegativeInt = Field(description="The number of datasets")
+    ds_count: NonNegativeInt = Field(
+        description="The number of datasets, as individual repos, "
+        "without any deduplication"
+    )
 
 
 class CollectionStats(BaseModel):

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -263,9 +263,11 @@ class AnnexDsCollectionStats(BaseModel):
     """
 
     ds_count: NonNegativeInt = Field(description="The number of datasets")
-    annexed_files_size: NonNegativeInt = Field(description="The size of annexed files")
-    annexed_file_count: NonNegativeInt = Field(
-        description="The number of annexed files"
+    annexed_files_size: Optional[NonNegativeInt] = Field(
+        None, description="The size of annexed files"
+    )
+    annexed_file_count: Optional[NonNegativeInt] = Field(
+        None, description="The number of annexed files"
     )
 
 

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -256,6 +256,10 @@ class DatasetURLRespModel(DatasetURLRespBaseModel):
         by_alias = False
 
 
+class CollectionStats(BaseModel):
+    pass
+
+
 class DatasetURLPage(BaseModel):
     """
     Model for representing a page of dataset URLs in response communication
@@ -274,4 +278,9 @@ class DatasetURLPage(BaseModel):
 
     dataset_urls: list[DatasetURLRespModel] = Field(
         description="The list of dataset URLs in the current page"
+    )
+    collection_stats: CollectionStats = Field(
+        description="Statistics about the collection of dataset URLs, "
+        "not just the URLs in the current page but the entire collection "
+        "returned"
     )

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -263,9 +263,7 @@ class AnnexDsCollectionStats(BaseModel):
     """
 
     ds_count: NonNegativeInt = Field(description="The number of datasets")
-    size_of_annexed_files: NonNegativeInt = Field(
-        description="The size of annexed files"
-    )
+    annexed_files_size: NonNegativeInt = Field(description="The size of annexed files")
     annexed_file_count: NonNegativeInt = Field(
         description="The number of annexed files"
     )

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -271,9 +271,9 @@ class _AnnexDsCollectionStats(BaseModel):
     )
 
 
-class AnnexDsCollectionStats(BaseModel):
+class DataladDsCollectionStats(BaseModel):
     """
-    Model for annex dataset collection statistics
+    Model for DataLad dataset collection statistics
     """
 
     unique_ds_stats: _AnnexDsCollectionStats = Field(
@@ -292,10 +292,10 @@ class StatsSummary(BaseModel):
 
 
 class CollectionStats(BaseModel):
-    datalad_ds_stats: AnnexDsCollectionStats = Field(
+    datalad_ds_stats: DataladDsCollectionStats = Field(
         description="Statistics for DataLad datasets"
     )
-    pure_annex_ds_stats: AnnexDsCollectionStats = Field(
+    pure_annex_ds_stats: DataladDsCollectionStats = Field(
         description="Statistics for pure annex datasets"
     )
     non_annex_ds_stats: NonAnnexDsStats = Field(

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -298,8 +298,9 @@ class CollectionStats(BaseModel):
     datalad_ds_stats: DataladDsCollectionStats = Field(
         description="Statistics for DataLad datasets"
     )
-    pure_annex_ds_stats: DataladDsCollectionStats = Field(
-        description="Statistics for pure annex datasets"
+    pure_annex_ds_stats: AnnexDsCollectionStats = Field(
+        description="Statistics for pure annex datasets, as individual repos, "
+        "without any deduplication"
     )
     non_annex_ds_stats: NonAnnexDsStats = Field(
         description="Statistics for non-annex datasets"

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -325,9 +325,6 @@ class DatasetURLPage(BaseModel):
     Model for representing a page of dataset URLs in response communication
     """
 
-    total: StrictInt = Field(
-        description="The total number of dataset URLs across all pages"
-    )
     cur_pg_num: StrictInt = Field(description="The number of the current page")
     prev_pg: Optional[StrictStr] = Field(
         None, description="The link to the previous page"

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -313,7 +313,8 @@ class CollectionStats(BaseModel):
         "without any deduplication"
     )
     non_annex_ds_stats: NonAnnexDsCollectionStats = Field(
-        description="Statistics for non-annex datasets"
+        description="Statistics for non-annex datasets, as individual repos, "
+        "without any deduplication"
     )
 
     summary: StatsSummary = Field(description="Summary statistics")

--- a/datalad_registry/blueprints/api/dataset_urls/tools.py
+++ b/datalad_registry/blueprints/api/dataset_urls/tools.py
@@ -1,4 +1,16 @@
-from sqlalchemy import Select, Subquery, and_, func, not_, or_, select
+from sqlalchemy import (
+    Select,
+    Subquery,
+    TableClause,
+    and_,
+    column,
+    func,
+    not_,
+    or_,
+    select,
+    table,
+    text,
+)
 
 from datalad_registry.models import RepoUrl, db
 
@@ -9,6 +21,29 @@ from .models import (
     NonAnnexDsCollectionStats,
     StatsSummary,
 )
+
+
+def cache_result_to_tmp_tb(select_stmt: Select, tb_name: str) -> TableClause:
+    """
+    Execute the given select statement and cache the result to a temporary table
+    with the given name
+
+    :param select_stmt: The given select statement to execute
+    :param tb_name: The string to use as the name of the temporary table
+    :return: A object representing the temporary table
+
+    Note: The execution of this function requires the Flask app's context
+    """
+    create_tmp_tb_sql = f"""
+        CREATE TEMPORARY TABLE {tb_name} AS
+        {select_stmt.compile(bind=db.engine, compile_kwargs={'literal_binds': True})};
+    """
+    db.session.execute(text(create_tmp_tb_sql))
+
+    return table(
+        tb_name,
+        *(column(name, c.type) for name, c in select_stmt.selected_columns.items()),
+    )
 
 
 def _get_annex_ds_collection_stats(q: Subquery) -> AnnexDsCollectionStats:

--- a/datalad_registry/blueprints/api/dataset_urls/tools.py
+++ b/datalad_registry/blueprints/api/dataset_urls/tools.py
@@ -1,0 +1,180 @@
+from sqlalchemy import Select, Subquery, and_, func, or_, select
+
+from datalad_registry.models import RepoUrl, db
+
+from .models import (
+    AnnexDsCollectionStats,
+    CollectionStats,
+    DataladDsCollectionStats,
+    NonAnnexDsCollectionStats,
+    StatsSummary,
+)
+
+
+def _get_annex_ds_collection_stats(q: Subquery) -> AnnexDsCollectionStats:
+    """
+    Get the stats of a collection of datasets that contains only of annex datasets
+
+    :param q: The query that specifies the collection of datasets under consideration
+    :return: The object representing the stats
+
+    Note: The execution of this function requires the Flask app's context
+    """
+
+    ds_count, annexed_files_size, annexed_file_count = db.session.execute(
+        select(
+            func.count().label("ds_count"),
+            func.sum(q.c.annexed_files_in_wt_size).label("annexed_files_size"),
+            func.sum(q.c.annexed_files_in_wt_count).label("annexed_file_count"),
+        ).select_from(q)
+    ).one()
+
+    return AnnexDsCollectionStats(
+        ds_count=ds_count,
+        annexed_files_size=annexed_files_size,
+        annexed_file_count=annexed_file_count,
+    )
+
+
+def get_unique_dl_ds_collection_stats(base_q: Subquery) -> AnnexDsCollectionStats:
+    """
+    Get the stats of the subset of the collection of datasets that contains only
+    of Datalad datasets, considering datasets with the same `ds_id` as the same
+    dataset
+
+    :param base_q: The base query that specified the collection of datasets
+                   under consideration
+    :return: The object representing the stats
+
+    Note: The execution of this function requires the Flask app's context
+    """
+
+    grp_by_id_q = (
+        select(
+            base_q.c.ds_id,
+            func.max(base_q.c.annexed_files_in_wt_size).label(
+                "max_annexed_files_in_wt_size"
+            ),
+        )
+        .group_by(base_q.c.ds_id)
+        .subquery("grp_by_id_q")
+    )
+
+    grp_by_id_and_a_f_size_q = (
+        select(
+            RepoUrl.ds_id,
+            RepoUrl.annexed_files_in_wt_size,
+            func.max(RepoUrl.annexed_files_in_wt_count).label(
+                "annexed_files_in_wt_count"
+            ),
+        )
+        .join(
+            grp_by_id_q,
+            and_(
+                RepoUrl.ds_id == grp_by_id_q.c.ds_id,
+                or_(
+                    grp_by_id_q.c.max_annexed_files_in_wt_size.is_(None),
+                    RepoUrl.annexed_files_in_wt_size
+                    == grp_by_id_q.c.max_annexed_files_in_wt_size,
+                ),
+            ),
+        )
+        .group_by(RepoUrl.ds_id, RepoUrl.annexed_files_in_wt_size)
+        .subquery("grp_by_id_and_a_f_size_q")
+    )
+
+    return _get_annex_ds_collection_stats(grp_by_id_and_a_f_size_q)
+
+
+def get_dl_ds_collection_stats_with_dups(base_q: Subquery) -> AnnexDsCollectionStats:
+    """
+    Get the stats of the subset of the collection of datasets that contains only
+    of Datalad datasets, considering individual repos as a dataset regardless of
+    the value of `ds_id`.
+
+    :param base_q: The base query that specified the collection of datasets
+                   under consideration
+    :return: The object representing the stats
+
+    Note: The execution of this function requires the Flask app's context
+    """
+
+    # Select statement for getting all the Datalad datasets
+    dl_ds_q = select(base_q).filter(base_q.c.ds_id.is_not(None)).subquery("dl_ds_q")
+
+    return _get_annex_ds_collection_stats(dl_ds_q)
+
+
+def get_dl_ds_collection_stats(base_q: Subquery) -> DataladDsCollectionStats:
+    """
+    Get the stats of the subset of the collection of datasets that contains only
+    of Datalad datasets
+
+    :param base_q: The base query that specified the collection of datasets
+                   under consideration
+    :return: The object representing the stats
+
+    Note: The execution of this function requires the Flask app's context
+    """
+
+    return DataladDsCollectionStats(
+        unique_ds_stats=get_unique_dl_ds_collection_stats(base_q),
+        stats=get_dl_ds_collection_stats_with_dups(base_q),
+    )
+
+
+def get_pure_annex_ds_collection_stats() -> AnnexDsCollectionStats:
+    """
+    Get the stats of the subset of the collection of datasets that contains only
+    of pure annex datasets, the annex datasets that are not Datalad datasets
+
+    :return: The object representing the stats
+
+    Note: The execution of this function requires the Flask app's context
+    """
+    # Select statement for getting all the pure annex datasets
+    pass
+
+
+def get_non_annex_ds_collection_stats() -> NonAnnexDsCollectionStats:
+    """
+    Get the stats of the subset of the collection of datasets that contains only
+    of non-annex datasets
+
+    :return: The object representing the stats
+
+    Note: The execution of this function requires the Flask app's context
+    """
+    pass
+
+
+def get_collection_stats(select_stmt: Select) -> CollectionStats:
+    """
+    Get the statistics of the collection of dataset URLs specified by the given select
+    statement
+
+    :param select_stmt: The given select statement
+    :return: The statistics of the collection of dataset URLs
+
+    Note: The execution of this function requires the Flask app's context
+    """
+
+    base_q = select_stmt.subquery("base_q")
+
+    datalad_ds_stats = get_dl_ds_collection_stats(base_q)
+    pure_annex_ds_stats = get_pure_annex_ds_collection_stats()
+    non_annex_ds_stats = get_non_annex_ds_collection_stats()
+
+    # Total number of datasets, as individual repos, without any deduplication
+    ds_count = db.session.execute(
+        select(func.count().label("ds_count")).select_from(base_q)
+    ).scalar_one()
+
+    return CollectionStats(
+        datalad_ds_stats=datalad_ds_stats,
+        pure_annex_ds_stats=pure_annex_ds_stats,
+        non_annex_ds_stats=non_annex_ds_stats,
+        summary=StatsSummary(
+            unique_ds_count=datalad_ds_stats.unique_ds_stats.ds_count, ds_count=ds_count
+        ),
+    )

--- a/datalad_registry/blueprints/api/dataset_urls/tools.py
+++ b/datalad_registry/blueprints/api/dataset_urls/tools.py
@@ -215,7 +215,11 @@ def get_collection_stats(select_stmt: Select) -> CollectionStats:
     Note: The execution of this function requires the Flask app's context
     """
 
-    base_q = select_stmt.subquery("base_q")
+    # Cache the result of the select statement to a temporary table
+    tmp_tb = cache_result_to_tmp_tb(select_stmt, "tmp_tb")
+
+    # base_q = select_stmt.subquery("base_q")
+    base_q = select(tmp_tb).subquery("base_q")
 
     datalad_ds_stats = get_dl_ds_collection_stats(base_q)
 

--- a/datalad_registry/blueprints/api/dataset_urls/tools.py
+++ b/datalad_registry/blueprints/api/dataset_urls/tools.py
@@ -183,8 +183,6 @@ def get_collection_stats(select_stmt: Select) -> CollectionStats:
     base_q = select_stmt.subquery("base_q")
 
     datalad_ds_stats = get_dl_ds_collection_stats(base_q)
-    pure_annex_ds_stats = get_pure_annex_ds_collection_stats(base_q)
-    non_annex_ds_stats = get_non_annex_ds_collection_stats(base_q)
 
     # Total number of datasets, as individual repos, without any deduplication
     ds_count = db.session.execute(
@@ -193,8 +191,8 @@ def get_collection_stats(select_stmt: Select) -> CollectionStats:
 
     return CollectionStats(
         datalad_ds_stats=datalad_ds_stats,
-        pure_annex_ds_stats=pure_annex_ds_stats,
-        non_annex_ds_stats=non_annex_ds_stats,
+        pure_annex_ds_stats=get_pure_annex_ds_collection_stats(base_q),
+        non_annex_ds_stats=get_non_annex_ds_collection_stats(base_q),
         summary=StatsSummary(
             unique_ds_count=datalad_ds_stats.unique_ds_stats.ds_count, ds_count=ds_count
         ),

--- a/datalad_registry/blueprints/api/utils.py
+++ b/datalad_registry/blueprints/api/utils.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 
 from flask import current_app, request
 
-from datalad_registry import OperationMode
+from datalad_registry.conf import OperationMode
 from datalad_registry.utils.flask_tools import json_resp_from_str
 
 from . import HTTPExceptionResp

--- a/datalad_registry/overview.py
+++ b/datalad_registry/overview.py
@@ -49,7 +49,6 @@ def overview():  # No type hints due to mypy#7187.
             select_stmt = select_stmt.filter(criteria)
 
     # Sort
-    select_stmt = select_stmt.group_by(RepoUrl)
     sort_by = request.args.get("sort", default_sort_scheme, type=str)
     if sort_by not in _SORT_ATTRS:
         lgr.debug("Ignoring unknown sort parameter: %s", sort_by)

--- a/datalad_registry/overview.py
+++ b/datalad_registry/overview.py
@@ -4,6 +4,7 @@
 import logging
 
 from flask import Blueprint, render_template, request
+from humanize import intcomma as h_intcomma
 from sqlalchemy import nullslast, select
 
 from datalad_registry.blueprints.api.dataset_urls.tools import get_collection_stats
@@ -27,6 +28,14 @@ _SORT_ATTRS = {
     "git_objects_kb-asc": ("git_objects_kb", "asc"),
     "git_objects_kb-desc": ("git_objects_kb", "desc"),
 }
+
+
+@bp.app_template_filter("intcomma")
+def intcomma(value, n_digits=None):
+    """
+    Wrapper around humanize.intcomma to be used in templates
+    """
+    return h_intcomma(value, n_digits)
 
 
 @bp.get("/")

--- a/datalad_registry/overview.py
+++ b/datalad_registry/overview.py
@@ -6,6 +6,7 @@ import logging
 from flask import Blueprint, render_template, request
 from sqlalchemy import nullslast, select
 
+from datalad_registry.blueprints.api.dataset_urls.tools import get_collection_stats
 from datalad_registry.models import RepoUrl, db
 from datalad_registry.search import parse_query
 
@@ -63,9 +64,13 @@ def overview():  # No type hints due to mypy#7187.
     # Paginate
     pagination = db.paginate(select_stmt)
 
+    # Gather stats of the returned collection of datasets
+    stats = get_collection_stats(base_select_stmt)
+
     return render_template(
         "overview.html",
         pagination=pagination,
+        stats=stats,
         sort_by=sort_by,
         search_query=query,
         search_error=search_error,

--- a/datalad_registry/overview.py
+++ b/datalad_registry/overview.py
@@ -32,7 +32,7 @@ _SORT_ATTRS = {
 def overview():  # No type hints due to mypy#7187.
     default_sort_scheme = "update-desc"
 
-    select_stmt = select(RepoUrl)
+    base_select_stmt = select(RepoUrl)
 
     # Search using query if provided.
     # ATM it is just a 'filter' on URL records, later might be more complex
@@ -46,7 +46,7 @@ def overview():  # No type hints due to mypy#7187.
         except Exception as e:
             search_error = str(e)
         else:
-            select_stmt = select_stmt.filter(criteria)
+            base_select_stmt = base_select_stmt.filter(criteria)
 
     # Decipher sorting scheme
     sort_by = request.args.get("sort", default_sort_scheme, type=str)
@@ -56,7 +56,7 @@ def overview():  # No type hints due to mypy#7187.
     col, sort_method = _SORT_ATTRS[sort_by]
 
     # Apply sorting
-    select_stmt = select_stmt.order_by(
+    select_stmt = base_select_stmt.order_by(
         nullslast(getattr(getattr(RepoUrl, col), sort_method)())
     )
 

--- a/datalad_registry/overview.py
+++ b/datalad_registry/overview.py
@@ -4,7 +4,7 @@
 import logging
 
 from flask import Blueprint, render_template, request
-from humanize import intcomma as h_intcomma
+from humanize import intcomma
 from sqlalchemy import nullslast, select
 
 from datalad_registry.blueprints.api.dataset_urls.tools import get_collection_stats
@@ -30,12 +30,8 @@ _SORT_ATTRS = {
 }
 
 
-@bp.app_template_filter("intcomma")
-def intcomma(value, n_digits=None):
-    """
-    Wrapper around humanize.intcomma to be used in templates
-    """
-    return h_intcomma(value, n_digits)
+# Register humanize.intcomma as a Jinja2 filter
+bp.add_app_template_filter(intcomma, "intcomma")
 
 
 @bp.get("/")

--- a/datalad_registry/overview.py
+++ b/datalad_registry/overview.py
@@ -48,12 +48,14 @@ def overview():  # No type hints due to mypy#7187.
         else:
             select_stmt = select_stmt.filter(criteria)
 
-    # Sort
+    # Decipher sorting scheme
     sort_by = request.args.get("sort", default_sort_scheme, type=str)
     if sort_by not in _SORT_ATTRS:
         lgr.debug("Ignoring unknown sort parameter: %s", sort_by)
         sort_by = default_sort_scheme
     col, sort_method = _SORT_ATTRS[sort_by]
+
+    # Apply sorting
     select_stmt = select_stmt.order_by(
         nullslast(getattr(getattr(RepoUrl, col), sort_method)())
     )

--- a/datalad_registry/static/main.css
+++ b/datalad_registry/static/main.css
@@ -120,7 +120,7 @@ div#datalad-registry div.pagination {
 /* Modal Content */
 .modal-content {
     position: fixed;
-    bottom: 50%;
+    top: 10%;
     background-color: #fefefe;
     width: 100%;
     -webkit-animation-name: slideIn;
@@ -131,13 +131,25 @@ div#datalad-registry div.pagination {
 
 /* Add Animation */
 @-webkit-keyframes slideIn {
-    from {bottom: -300px; opacity: 0}
-    to {bottom: 50%; opacity: 1}
+    from {
+        top: 50%;
+        opacity: 0
+    }
+    to {
+        top: 10%;
+        opacity: 1
+    }
 }
 
 @keyframes slideIn {
-    from {bottom: -300px; opacity: 0}
-    to {bottom: 50%; opacity: 1}
+    from {
+        top: 50%;
+        opacity: 0
+    }
+    to {
+        top: 10%;
+        opacity: 1
+    }
 }
 
 @-webkit-keyframes fadeIn {

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -251,7 +251,7 @@ const syntax_modal = document.getElementById("QuerySyntaxModal");
 const show_syntax_btn = document.getElementById("showQuerySyntax");
 
 // Get the <span> element that closes the syntax modal
-const close_syntax_span = document.getElementsByClassName("close")[0];
+const close_syntax_span = document.getElementById("CloseSyntax");
 
 // When the user clicks the show syntax button, open the syntax modal
 show_syntax_btn.onclick = function() {

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -29,10 +29,10 @@
 
 {% macro render_annex_ds_collection_stats(annex_ds_col_stats) %}
   <ul>
-    <li>Count: {{ annex_ds_col_stats.ds_count }}</li>
+    <li>Count: {{ annex_ds_col_stats.ds_count|intcomma }}</li>
     {% if annex_ds_col_stats.annexed_file_count is not none %}
       <li>Annexed file
-        count: {{ annex_ds_col_stats.annexed_file_count }}</li>
+        count: {{ annex_ds_col_stats.annexed_file_count|intcomma }}</li>
     {% endif %}
     {% if annex_ds_col_stats.annexed_files_size is not none %}
       <li>Annexed files
@@ -195,8 +195,8 @@
 
     <div>
       Combined Nr of Annexed
-      files: {{ (stats.datalad_ds_stats.stats.annexed_file_count if stats.datalad_ds_stats.stats.annexed_file_count else 0) +
-        (stats.pure_annex_ds_stats.annexed_file_count if stats.pure_annex_ds_stats.annexed_file_count else 0) }}
+      files: {{ ((stats.datalad_ds_stats.stats.annexed_file_count if stats.datalad_ds_stats.stats.annexed_file_count else 0) +
+        (stats.pure_annex_ds_stats.annexed_file_count if stats.pure_annex_ds_stats.annexed_file_count else 0))|intcomma }}
       Combined Annexed file
       size: {{ ((stats.datalad_ds_stats.stats.annexed_files_size if stats.datalad_ds_stats.stats.annexed_files_size else 0) + (stats.pure_annex_ds_stats.annexed_files_size if stats.pure_annex_ds_stats.annexed_files_size else 0))|filesizeformat }}
 
@@ -234,15 +234,15 @@
             <li>
               <h3>Non-Annex Dataset Stats</h3>
               <ul>
-                <li>Count: {{ stats.non_annex_ds_stats.ds_count }}</li>
+                <li>Count: {{ stats.non_annex_ds_stats.ds_count|intcomma }}</li>
               </ul>
             </li>
             <li>
               <h3>Summary</h3>
               <ul>
-                <li>Unique dataset count: {{ stats.summary.unique_ds_count }}</li>
+                <li>Unique dataset count: {{ stats.summary.unique_ds_count|intcomma }}</li>
                 <li>Total dataset count (without
-                  deduplication): {{ stats.summary.ds_count }}</li>
+                  deduplication): {{ stats.summary.ds_count|intcomma }}</li>
               </ul>
             </li>
           </ul>

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -36,7 +36,7 @@
     {% endif %}
     {% if annex_ds_col_stats.annexed_files_size is not none %}
       <li>Annexed files
-        size: {{ annex_ds_col_stats.annexed_files_size }}</li>
+        size: {{ annex_ds_col_stats.annexed_files_size }} bytes</li>
     {% endif %}
   </ul>
 {% endmacro %}

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -75,9 +75,8 @@
     {%- endif %}
     <button id="showQuerySyntax">Show search query syntax</button>
 
+    <!-- Syntax modal -->
     <div id="QuerySyntaxModal" class="modal">
-
-    <!-- Modal content -->
       <div class="modal-content">
         <div class="modal-header">
           <span class="close">&times;</span>
@@ -196,7 +195,7 @@
     <!-- Stats Trigger Button -->
     <button id="statsModalBtn">Show Stats</button>
 
-    <!-- Statistics of the returned collection of datasets -->
+    <!-- Statistics modal -->
     <div id="statsModal" class="modal">
       <div class="modal-content">
         <div class="modal-header">

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -193,6 +193,9 @@
       {{ render_pagination_widget(pagination, '.overview') }}
     </div>
 
+    <!-- Stats Trigger Button -->
+    <button id="statsModalBtn">Show Stats</button>
+
     <!-- Statistics of the returned collection of datasets -->
     <div id="stats">
       <h2>Stats</h2>

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -201,7 +201,7 @@
       size: {{ (stats.datalad_ds_stats.stats.annexed_files_size if stats.datalad_ds_stats.stats.annexed_files_size else 0) + (stats.pure_annex_ds_stats.annexed_files_size if stats.pure_annex_ds_stats.annexed_files_size else 0) }}
 
       <!-- Stats Trigger Button -->
-      <button id="ShowStats">Show Stats</button>
+      <button id="ShowStats">Show Details</button>
     </div>
 
 

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -178,6 +178,74 @@
     <div class="pager">
       {{ render_pagination_widget(pagination, '.overview') }}
     </div>
+
+    <!-- Statistics of the returned collection of datasets -->
+    <div id="stats">
+      <h2>Stats</h2>
+      <ul>
+        <li>
+          <h3>Datalad Datasets Stats</h3>
+          <ul>
+            <li>
+              <h4>Unique Datalad Dataset Stats</h4>
+              <ul>
+                <li>Count: {{ stats.datalad_ds_stats.unique_ds_stats.ds_count }}</li>
+                {% if stats.datalad_ds_stats.unique_ds_stats.annexed_file_count is not none %}
+                  <li>Annexed file
+                    count: {{ stats.datalad_ds_stats.unique_ds_stats.annexed_file_count }}</li>
+                {% endif %}
+                {% if stats.datalad_ds_stats.unique_ds_stats.annexed_files_size is not none %}
+                  <li>Annexed files
+                    size: {{ stats.datalad_ds_stats.unique_ds_stats.annexed_files_size }}</li>
+                {% endif %}
+              </ul>
+            </li>
+            <li>
+              <h4>Stats without deduplication</h4>
+              <ul>
+                <li>Count: {{ stats.datalad_ds_stats.stats.ds_count }}</li>
+                {% if stats.datalad_ds_stats.stats.annexed_file_count is not none %}
+                  <li>Annexed file
+                    count: {{ stats.datalad_ds_stats.stats.annexed_file_count }}</li>
+                {% endif %}
+                {% if stats.datalad_ds_stats.stats.annexed_files_size is not none %}
+                  <li>Annexed files
+                    size: {{ stats.datalad_ds_stats.stats.annexed_files_size }}</li>
+                {% endif %}
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <h3>Pure Annex Dataset Stats</h3>
+          <ul>
+            <li>Count: {{ stats.pure_annex_ds_stats.ds_count }}</li>
+            {% if stats.pure_annex_ds_stats.annexed_file_count is not none %}
+              <li>Annexed file
+                count: {{ stats.pure_annex_ds_stats.annexed_file_count }}</li>
+            {% endif %}
+            {% if stats.pure_annex_ds_stats.annexed_files_size is not none %}
+              <li>Annexed files
+                size: {{ stats.pure_annex_ds_stats.annexed_files_size }}</li>
+            {% endif %}
+          </ul>
+        </li>
+        <li>
+          <h3>Non-Annex Dataset Stats</h3>
+          <ul>
+            <li>Count: {{ stats.non_annex_ds_stats.ds_count }}</li>
+          </ul>
+        </li>
+        <li>
+          <h3>Summary</h3>
+          <ul>
+            <li>Unique dataset count: {{ stats.summary.unique_ds_count }}</li>
+            <li>Total dataset count (without
+              deduplication): {{ stats.summary.ds_count }}</li>
+          </ul>
+        </li>
+      </ul>
+    </div>
   </div>
 </div>
 

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -263,10 +263,32 @@ close_syntax_span.onclick = function() {
   syntax_modal.style.display = "none";
 }
 
+// Get the stats modal
+const stats_modal = document.getElementById("StatsModal");
+
+// Get the button that opens the stats modal
+const show_stats_btn = document.getElementById("ShowStats");
+
+// Get the <span> element that closes the stats modal
+const close_stats_span = document.getElementById("CloseStats");
+
+// When the user clicks the show stats button, open the syntax modal
+show_stats_btn.onclick = function() {
+  stats_modal.style.display = "block";
+}
+
+// When the user clicks on <span> (x), close the stats modal
+close_stats_span.onclick = function() {
+  stats_modal.style.display = "none";
+}
+
 // When the user clicks anywhere outside the modal, close it
 window.onclick = function(event) {
   if (event.target === syntax_modal) {
     syntax_modal.style.display = "none";
+  }
+  if (event.target === stats_modal) {
+    stats_modal.style.display = "none";
   }
 }
 

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -79,7 +79,7 @@
     <div id="QuerySyntaxModal" class="modal">
       <div class="modal-content">
         <div class="modal-header">
-          <span class="close">&times;</span>
+          <span id="CloseSyntax" class="close">&times;</span>
           <h2>Search query syntax</h2>
         </div>
         <div class="modal-body">
@@ -199,7 +199,7 @@
     <div id="statsModal" class="modal">
       <div class="modal-content">
         <div class="modal-header">
-          <span class="close">&times;</span>
+          <span id="CloseStats" class="close">&times;</span>
           <h2>Stats</h2>
         </div>
         <div id="stats" class="modal-body">

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -245,29 +245,29 @@
 </div>
 
 <script>
-// Get the modal
-const modal = document.getElementById("QuerySyntaxModal");
+// Get the syntax modal
+const syntax_modal = document.getElementById("QuerySyntaxModal");
 
-// Get the button that opens the modal
-const btn = document.getElementById("showQuerySyntax");
+// Get the button that opens the syntax modal
+const show_syntax_btn = document.getElementById("showQuerySyntax");
 
-// Get the <span> element that closes the modal
-const span = document.getElementsByClassName("close")[0];
+// Get the <span> element that closes the syntax modal
+const close_syntax_span = document.getElementsByClassName("close")[0];
 
-// When the user clicks the button, open the modal
-btn.onclick = function() {
-  modal.style.display = "block";
+// When the user clicks the show syntax button, open the syntax modal
+show_syntax_btn.onclick = function() {
+  syntax_modal.style.display = "block";
 }
 
-// When the user clicks on <span> (x), close the modal
-span.onclick = function() {
-  modal.style.display = "none";
+// When the user clicks on <span> (x), close the syntax modal
+close_syntax_span.onclick = function() {
+  syntax_modal.style.display = "none";
 }
 
 // When the user clicks anywhere outside the modal, close it
 window.onclick = function(event) {
-  if (event.target === modal) {
-    modal.style.display = "none";
+  if (event.target === syntax_modal) {
+    syntax_modal.style.display = "none";
   }
 }
 

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -194,14 +194,14 @@
 
 
     <div>
-      <span style="margin-right: 10px">Combined Nr of Annexed
+      <span style="margin-right: 10px"># of annexed
       files: {{ ((stats.datalad_ds_stats.stats.annexed_file_count if stats.datalad_ds_stats.stats.annexed_file_count else 0) +
         (stats.pure_annex_ds_stats.annexed_file_count if stats.pure_annex_ds_stats.annexed_file_count else 0))|intcomma }}</span>
-      <span style="margin-right: 5px">Combined Annexed file
-        size: {{ ((stats.datalad_ds_stats.stats.annexed_files_size if stats.datalad_ds_stats.stats.annexed_files_size else 0) + (stats.pure_annex_ds_stats.annexed_files_size if stats.pure_annex_ds_stats.annexed_files_size else 0))|filesizeformat }}</span>
+      <span style="margin-right: 5px">Combined size of annexed
+        files: {{ ((stats.datalad_ds_stats.stats.annexed_files_size if stats.datalad_ds_stats.stats.annexed_files_size else 0) + (stats.pure_annex_ds_stats.annexed_files_size if stats.pure_annex_ds_stats.annexed_files_size else 0))|filesizeformat }}</span>
 
       <!-- Stats Trigger Button -->
-      <button id="ShowStats">Show Details</button>
+      <button id="ShowStats">Show details</button>
     </div>
 
 
@@ -215,10 +215,10 @@
         <div id="stats" class="modal-body">
           <ul>
             <li>
-              <h3>Datalad Datasets Stats</h3>
+              <h3>DataLad datasets stats</h3>
               <ul>
                 <li>
-                  <h4>Unique Datalad Dataset Stats</h4>
+                  <h4>Unique DataLad dataset stats</h4>
                   {{ render_annex_ds_collection_stats(stats.datalad_ds_stats.unique_ds_stats) }}
                 </li>
                 <li>
@@ -228,11 +228,11 @@
               </ul>
             </li>
             <li>
-              <h3>Pure Annex Dataset Stats</h3>
+              <h3>Pure annex repositories stats</h3>
               {{ render_annex_ds_collection_stats(stats.pure_annex_ds_stats) }}
             </li>
             <li>
-              <h3>Non-Annex Dataset Stats</h3>
+              <h3>Non-annex repositories stats</h3>
               <ul>
                 <li>Count: {{ stats.non_annex_ds_stats.ds_count|intcomma }}</li>
               </ul>

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -192,8 +192,18 @@
       {{ render_pagination_widget(pagination, '.overview') }}
     </div>
 
-    <!-- Stats Trigger Button -->
-    <button id="ShowStats">Show Stats</button>
+
+    <div>
+      Combined Nr of Annexed
+      files: {{ (stats.datalad_ds_stats.stats.annexed_file_count if stats.datalad_ds_stats.stats.annexed_file_count else 0) +
+        (stats.pure_annex_ds_stats.annexed_file_count if stats.pure_annex_ds_stats.annexed_file_count else 0) }}
+      Combined Annexed file
+      size: {{ (stats.datalad_ds_stats.stats.annexed_files_size if stats.datalad_ds_stats.stats.annexed_files_size else 0) + (stats.pure_annex_ds_stats.annexed_files_size if stats.pure_annex_ds_stats.annexed_files_size else 0) }}
+
+      <!-- Stats Trigger Button -->
+      <button id="ShowStats">Show Stats</button>
+    </div>
+
 
     <!-- Statistics modal -->
     <div id="StatsModal" class="modal">

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -197,41 +197,49 @@
     <button id="statsModalBtn">Show Stats</button>
 
     <!-- Statistics of the returned collection of datasets -->
-    <div id="stats">
-      <h2>Stats</h2>
-      <ul>
-        <li>
-          <h3>Datalad Datasets Stats</h3>
+    <div id="statsModal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <span class="close">&times;</span>
+          <h2>Stats</h2>
+        </div>
+        <div id="stats" class="modal-body">
+          <h2>Stats</h2>
           <ul>
             <li>
-              <h4>Unique Datalad Dataset Stats</h4>
-              {{ render_annex_ds_collection_stats(stats.datalad_ds_stats.unique_ds_stats) }}
+              <h3>Datalad Datasets Stats</h3>
+              <ul>
+                <li>
+                  <h4>Unique Datalad Dataset Stats</h4>
+                  {{ render_annex_ds_collection_stats(stats.datalad_ds_stats.unique_ds_stats) }}
+                </li>
+                <li>
+                  <h4>Stats without deduplication</h4>
+                  {{ render_annex_ds_collection_stats(stats.datalad_ds_stats.stats) }}
+                </li>
+              </ul>
             </li>
             <li>
-              <h4>Stats without deduplication</h4>
-              {{ render_annex_ds_collection_stats(stats.datalad_ds_stats.stats) }}
+              <h3>Pure Annex Dataset Stats</h3>
+              {{ render_annex_ds_collection_stats(stats.pure_annex_ds_stats) }}
+            </li>
+            <li>
+              <h3>Non-Annex Dataset Stats</h3>
+              <ul>
+                <li>Count: {{ stats.non_annex_ds_stats.ds_count }}</li>
+              </ul>
+            </li>
+            <li>
+              <h3>Summary</h3>
+              <ul>
+                <li>Unique dataset count: {{ stats.summary.unique_ds_count }}</li>
+                <li>Total dataset count (without
+                  deduplication): {{ stats.summary.ds_count }}</li>
+              </ul>
             </li>
           </ul>
-        </li>
-        <li>
-          <h3>Pure Annex Dataset Stats</h3>
-          {{ render_annex_ds_collection_stats(stats.pure_annex_ds_stats) }}
-        </li>
-        <li>
-          <h3>Non-Annex Dataset Stats</h3>
-          <ul>
-            <li>Count: {{ stats.non_annex_ds_stats.ds_count }}</li>
-          </ul>
-        </li>
-        <li>
-          <h3>Summary</h3>
-          <ul>
-            <li>Unique dataset count: {{ stats.summary.unique_ds_count }}</li>
-            <li>Total dataset count (without
-              deduplication): {{ stats.summary.ds_count }}</li>
-          </ul>
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -27,6 +27,20 @@
   </div>
 {% endmacro %}
 
+{% macro render_annex_ds_collection_stats(annex_ds_col_stats) %}
+  <ul>
+    <li>Count: {{ annex_ds_col_stats.ds_count }}</li>
+    {% if annex_ds_col_stats.annexed_file_count is not none %}
+      <li>Annexed file
+        count: {{ annex_ds_col_stats.annexed_file_count }}</li>
+    {% endif %}
+    {% if annex_ds_col_stats.annexed_files_size is not none %}
+      <li>Annexed files
+        size: {{ annex_ds_col_stats.annexed_files_size }}</li>
+    {% endif %}
+  </ul>
+{% endmacro %}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -188,47 +202,17 @@
           <ul>
             <li>
               <h4>Unique Datalad Dataset Stats</h4>
-              <ul>
-                <li>Count: {{ stats.datalad_ds_stats.unique_ds_stats.ds_count }}</li>
-                {% if stats.datalad_ds_stats.unique_ds_stats.annexed_file_count is not none %}
-                  <li>Annexed file
-                    count: {{ stats.datalad_ds_stats.unique_ds_stats.annexed_file_count }}</li>
-                {% endif %}
-                {% if stats.datalad_ds_stats.unique_ds_stats.annexed_files_size is not none %}
-                  <li>Annexed files
-                    size: {{ stats.datalad_ds_stats.unique_ds_stats.annexed_files_size }}</li>
-                {% endif %}
-              </ul>
+              {{ render_annex_ds_collection_stats(stats.datalad_ds_stats.unique_ds_stats) }}
             </li>
             <li>
               <h4>Stats without deduplication</h4>
-              <ul>
-                <li>Count: {{ stats.datalad_ds_stats.stats.ds_count }}</li>
-                {% if stats.datalad_ds_stats.stats.annexed_file_count is not none %}
-                  <li>Annexed file
-                    count: {{ stats.datalad_ds_stats.stats.annexed_file_count }}</li>
-                {% endif %}
-                {% if stats.datalad_ds_stats.stats.annexed_files_size is not none %}
-                  <li>Annexed files
-                    size: {{ stats.datalad_ds_stats.stats.annexed_files_size }}</li>
-                {% endif %}
-              </ul>
+              {{ render_annex_ds_collection_stats(stats.datalad_ds_stats.stats) }}
             </li>
           </ul>
         </li>
         <li>
           <h3>Pure Annex Dataset Stats</h3>
-          <ul>
-            <li>Count: {{ stats.pure_annex_ds_stats.ds_count }}</li>
-            {% if stats.pure_annex_ds_stats.annexed_file_count is not none %}
-              <li>Annexed file
-                count: {{ stats.pure_annex_ds_stats.annexed_file_count }}</li>
-            {% endif %}
-            {% if stats.pure_annex_ds_stats.annexed_files_size is not none %}
-              <li>Annexed files
-                size: {{ stats.pure_annex_ds_stats.annexed_files_size }}</li>
-            {% endif %}
-          </ul>
+          {{ render_annex_ds_collection_stats(stats.pure_annex_ds_stats) }}
         </li>
         <li>
           <h3>Non-Annex Dataset Stats</h3>

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -36,7 +36,7 @@
     {% endif %}
     {% if annex_ds_col_stats.annexed_files_size is not none %}
       <li>Annexed files
-        size: {{ annex_ds_col_stats.annexed_files_size }} bytes</li>
+        size: {{ annex_ds_col_stats.annexed_files_size|filesizeformat }} </li>
     {% endif %}
   </ul>
 {% endmacro %}
@@ -198,7 +198,7 @@
       files: {{ (stats.datalad_ds_stats.stats.annexed_file_count if stats.datalad_ds_stats.stats.annexed_file_count else 0) +
         (stats.pure_annex_ds_stats.annexed_file_count if stats.pure_annex_ds_stats.annexed_file_count else 0) }}
       Combined Annexed file
-      size: {{ (stats.datalad_ds_stats.stats.annexed_files_size if stats.datalad_ds_stats.stats.annexed_files_size else 0) + (stats.pure_annex_ds_stats.annexed_files_size if stats.pure_annex_ds_stats.annexed_files_size else 0) }}
+      size: {{ ((stats.datalad_ds_stats.stats.annexed_files_size if stats.datalad_ds_stats.stats.annexed_files_size else 0) + (stats.pure_annex_ds_stats.annexed_files_size if stats.pure_annex_ds_stats.annexed_files_size else 0))|filesizeformat }}
 
       <!-- Stats Trigger Button -->
       <button id="ShowStats">Show Details</button>

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -194,11 +194,11 @@
 
 
     <div>
-      Combined Nr of Annexed
+      <span style="margin-right: 10px">Combined Nr of Annexed
       files: {{ ((stats.datalad_ds_stats.stats.annexed_file_count if stats.datalad_ds_stats.stats.annexed_file_count else 0) +
-        (stats.pure_annex_ds_stats.annexed_file_count if stats.pure_annex_ds_stats.annexed_file_count else 0))|intcomma }}
-      Combined Annexed file
-      size: {{ ((stats.datalad_ds_stats.stats.annexed_files_size if stats.datalad_ds_stats.stats.annexed_files_size else 0) + (stats.pure_annex_ds_stats.annexed_files_size if stats.pure_annex_ds_stats.annexed_files_size else 0))|filesizeformat }}
+        (stats.pure_annex_ds_stats.annexed_file_count if stats.pure_annex_ds_stats.annexed_file_count else 0))|intcomma }}</span>
+      <span style="margin-right: 5px">Combined Annexed file
+        size: {{ ((stats.datalad_ds_stats.stats.annexed_files_size if stats.datalad_ds_stats.stats.annexed_files_size else 0) + (stats.pure_annex_ds_stats.annexed_files_size if stats.pure_annex_ds_stats.annexed_files_size else 0))|filesizeformat }}</span>
 
       <!-- Stats Trigger Button -->
       <button id="ShowStats">Show Details</button>

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -203,7 +203,6 @@
           <h2>Stats</h2>
         </div>
         <div id="stats" class="modal-body">
-          <h2>Stats</h2>
           <ul>
             <li>
               <h3>Datalad Datasets Stats</h3>

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -243,53 +243,37 @@
 </div>
 
 <script>
-// Get the syntax modal
-const syntax_modal = document.getElementById("QuerySyntaxModal");
+    function setupModal(modalId, btnShowId, btnCloseId) {
+        const modal = document.getElementById(modalId);
+        const btnShow = document.getElementById(btnShowId);
+        const btnClose = document.getElementById(btnCloseId);
 
-// Get the button that opens the syntax modal
-const show_syntax_btn = document.getElementById("ShowQuerySyntax");
+        // When the user clicks the button, open the modal
+        btnShow.onclick = function () {
+            modal.style.display = "block";
+        }
 
-// Get the <span> element that closes the syntax modal
-const close_syntax_span = document.getElementById("CloseSyntax");
+        // When the user clicks on <span> (x), close the modal
+        btnClose.onclick = function () {
+            modal.style.display = "none";
+        }
 
-// When the user clicks the show syntax button, open the syntax modal
-show_syntax_btn.onclick = function() {
-  syntax_modal.style.display = "block";
-}
+        return modal;
+    }
 
-// When the user clicks on <span> (x), close the syntax modal
-close_syntax_span.onclick = function() {
-  syntax_modal.style.display = "none";
-}
+    // Setup modals
+    const modals = [];
+    modals.push(setupModal('QuerySyntaxModal', 'ShowQuerySyntax', 'CloseSyntax'));
+    modals.push(setupModal('StatsModal', 'ShowStats', 'CloseStats'));
 
-// Get the stats modal
-const stats_modal = document.getElementById("StatsModal");
-
-// Get the button that opens the stats modal
-const show_stats_btn = document.getElementById("ShowStats");
-
-// Get the <span> element that closes the stats modal
-const close_stats_span = document.getElementById("CloseStats");
-
-// When the user clicks the show stats button, open the syntax modal
-show_stats_btn.onclick = function() {
-  stats_modal.style.display = "block";
-}
-
-// When the user clicks on <span> (x), close the stats modal
-close_stats_span.onclick = function() {
-  stats_modal.style.display = "none";
-}
-
-// When the user clicks anywhere outside the modal, close it
-window.onclick = function(event) {
-  if (event.target === syntax_modal) {
-    syntax_modal.style.display = "none";
-  }
-  if (event.target === stats_modal) {
-    stats_modal.style.display = "none";
-  }
-}
+    // When the user clicks anywhere outside the modal, close it
+    window.onclick = function (event) {
+        modals.forEach(function (modal) {
+            if (event.target === modal) {
+                modal.style.display = "none";
+            }
+        });
+    }
 
 function span_copy() {
   // Find all span elements with the class 'query'

--- a/datalad_registry/templates/overview.html
+++ b/datalad_registry/templates/overview.html
@@ -73,7 +73,7 @@
         <input type='submit' value='Clear'/>
         </form>
     {%- endif %}
-    <button id="showQuerySyntax">Show search query syntax</button>
+    <button id="ShowQuerySyntax">Show search query syntax</button>
 
     <!-- Syntax modal -->
     <div id="QuerySyntaxModal" class="modal">
@@ -193,10 +193,10 @@
     </div>
 
     <!-- Stats Trigger Button -->
-    <button id="statsModalBtn">Show Stats</button>
+    <button id="ShowStats">Show Stats</button>
 
     <!-- Statistics modal -->
-    <div id="statsModal" class="modal">
+    <div id="StatsModal" class="modal">
       <div class="modal-content">
         <div class="modal-header">
           <span id="CloseStats" class="close">&times;</span>
@@ -248,7 +248,7 @@
 const syntax_modal = document.getElementById("QuerySyntaxModal");
 
 // Get the button that opens the syntax modal
-const show_syntax_btn = document.getElementById("showQuerySyntax");
+const show_syntax_btn = document.getElementById("ShowQuerySyntax");
 
 // Get the <span> element that closes the syntax modal
 const close_syntax_span = document.getElementById("CloseSyntax");

--- a/datalad_registry/tests/conftest.py
+++ b/datalad_registry/tests/conftest.py
@@ -258,12 +258,28 @@ def populate_with_2_dataset_urls(flask_app):
         db.session.commit()
 
 
+def _populate_with_dataset_urls(urls: list[RepoUrl], flask_app):
+    """
+    Populate the `repo_url` table with a list of RepoUrl objects
+
+    :param urls: The list of RepoUrl objects to populate
+    :return: The list of URLs, expressed in `str`, that were added to the database
+    """
+
+    with flask_app.app_context():
+        for url in urls:
+            db.session.add(url)
+        db.session.commit()
+
+        return [url.url for url in urls]
+
+
 @pytest.fixture
 def populate_with_dataset_urls(flask_app) -> list[str]:
     """
-    Populate the url table with a list of DatasetURLs.
+    Populate the `repo_url` table with a list of RepoUrl objects
 
-    Returns: The list of DatasetURLs that were added to the database
+    Returns: The list of URLs, expressed in `str`, that were added to the database
     """
 
     urls = [
@@ -319,12 +335,7 @@ def populate_with_dataset_urls(flask_app) -> list[str]:
         ),
     ]
 
-    with flask_app.app_context():
-        for url in urls:
-            db.session.add(url)
-        db.session.commit()
-
-        return [url.url for url in urls]
+    return _populate_with_dataset_urls(urls, flask_app)
 
 
 @pytest.fixture

--- a/datalad_registry/tests/conftest.py
+++ b/datalad_registry/tests/conftest.py
@@ -275,9 +275,9 @@ def _populate_with_dataset_urls(urls: list[RepoUrl], flask_app):
 
 
 @pytest.fixture
-def populate_with_dataset_urls(flask_app) -> list[str]:
+def populate_with_std_ds_urls(flask_app) -> list[str]:
     """
-    Populate the `repo_url` table with a list of RepoUrl objects
+    Populate the `repo_url` table with a list of standard (typical) RepoUrl objects
 
     Returns: The list of URLs, expressed in `str`, that were added to the database
     """
@@ -340,7 +340,7 @@ def populate_with_dataset_urls(flask_app) -> list[str]:
 
 @pytest.fixture
 def populate_with_url_metadata(
-    populate_with_dataset_urls,  # noqa: U100 (unused argument)
+    populate_with_std_ds_urls,  # noqa: U100 (unused argument)
     flask_app,
 ):
     """

--- a/datalad_registry/tests/conftest.py
+++ b/datalad_registry/tests/conftest.py
@@ -16,6 +16,8 @@ from datalad_registry import create_app
 from datalad_registry.models import RepoUrl, URLMetadata, db
 from datalad_registry.utils.datalad_tls import clone
 
+from .tools import populate_with_dataset_urls
+
 
 @pytest.fixture(scope="session")
 def set_test_env(tmp_path_factory):
@@ -258,22 +260,6 @@ def populate_with_2_dataset_urls(flask_app):
         db.session.commit()
 
 
-def _populate_with_dataset_urls(urls: list[RepoUrl], flask_app):
-    """
-    Populate the `repo_url` table with a list of RepoUrl objects
-
-    :param urls: The list of RepoUrl objects to populate
-    :return: The list of URLs, expressed in `str`, that were added to the database
-    """
-
-    with flask_app.app_context():
-        for url in urls:
-            db.session.add(url)
-        db.session.commit()
-
-        return [url.url for url in urls]
-
-
 @pytest.fixture
 def populate_with_std_ds_urls(flask_app) -> list[str]:
     """
@@ -335,7 +321,7 @@ def populate_with_std_ds_urls(flask_app) -> list[str]:
         ),
     ]
 
-    return _populate_with_dataset_urls(urls, flask_app)
+    return populate_with_dataset_urls(urls, flask_app)
 
 
 @pytest.fixture

--- a/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
@@ -398,12 +398,12 @@ class TestDatasetURLs:
 
         ds_url_page = DatasetURLPage.parse_raw(resp.text)
 
-        assert ds_url_page.total == expected_out_count
         assert ds_url_page.cur_pg_num == DEFAULT_PAGE
         assert ds_url_page.prev_pg is None
         assert ds_url_page.next_pg is None
         assert YURL(ds_url_page.first_pg).query["page"] == "1"
         assert YURL(ds_url_page.last_pg).query["page"] == "1"
+        assert ds_url_page.collection_stats.summary.ds_count == expected_out_count
 
         # Check the collection of dataset URLs
         assert {i.url for i in ds_url_page.dataset_urls} == expected_output
@@ -510,11 +510,11 @@ class TestDatasetURLs:
         resp_json = resp.json
         ds_url_pg = DatasetURLPage.parse_obj(resp_json)
 
-        assert ds_url_pg.total == 4
         assert ds_url_pg.cur_pg_num == 1
         assert "prev_pg" not in resp_json
         assert ds_url_pg.prev_pg is None
         assert ds_url_pg.next_pg is not None
+        assert ds_url_pg.collection_stats.summary.ds_count == 4
 
         next_pg_lk, first_pg_lk, last_pg_lk = (
             YURL(pg)
@@ -548,11 +548,11 @@ class TestDatasetURLs:
         resp_json = resp.json
         ds_url_pg = DatasetURLPage.parse_obj(resp_json)
 
-        assert ds_url_pg.total == 4
         assert ds_url_pg.cur_pg_num == 2
         assert ds_url_pg.prev_pg is not None
         assert "next_pg" not in resp_json
         assert ds_url_pg.next_pg is None
+        assert ds_url_pg.collection_stats.summary.ds_count == 4
 
         prev_pg_lk, first_pg_lk, last_pg_lk = (
             YURL(pg)

--- a/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
@@ -119,7 +119,7 @@ class TestDeclareDatasetURL:
                 "/api/v2/dataset-urls", json={"url": "https://www.example.com"}
             )
 
-    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
     @pytest.mark.parametrize(
         "url, expected_mark_for_chk_delay_args",
         [
@@ -255,7 +255,7 @@ class TestDatasetURLs:
         resp = flask_client.get("/api/v2/dataset-urls", query_string=query_params)
         assert resp.status_code == 200
 
-    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
     @pytest.mark.parametrize(
         "query_params, expected_output",
         [
@@ -408,7 +408,7 @@ class TestDatasetURLs:
         # Check the collection of dataset URLs
         assert {i.url for i in ds_url_page.dataset_urls} == expected_output
 
-    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
     @pytest.mark.parametrize(
         "query_params",
         [
@@ -494,7 +494,7 @@ class TestDatasetURLs:
 
                 assert all(type(m) is metadata_ret_type for m in url.metadata)
 
-    def test_pagination(self, populate_with_dataset_urls, flask_client):
+    def test_pagination(self, populate_with_std_ds_urls, flask_client):
         """
         Test the pagination of the results
         """
@@ -578,9 +578,9 @@ class TestDatasetURLs:
         for url in ds_url_pg.dataset_urls:
             ds_urls.add(str(url.url))
 
-        assert ds_urls == set(populate_with_dataset_urls)
+        assert ds_urls == set(populate_with_std_ds_urls)
 
-    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
     @pytest.mark.parametrize(
         "query_params, expected_results_by_id_prefix",
         [

--- a/datalad_registry/tests/test_overview.py
+++ b/datalad_registry/tests/test_overview.py
@@ -6,7 +6,7 @@ from yarl import URL as YURL
 
 
 class TestOverView:
-    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
     @pytest.mark.parametrize(
         "sort_by, expected_order",
         [
@@ -143,7 +143,7 @@ class TestOverView:
 
         assert url_list == expected_order
 
-    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
     @pytest.mark.parametrize(
         "search_query, expected_results",
         [
@@ -180,7 +180,7 @@ class TestOverView:
 
         assert url_list == expected_results
 
-    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
     @pytest.mark.parametrize(
         "search_query, err_msg_prefix",
         [
@@ -206,7 +206,7 @@ class TestOverView:
         assert (error_span := soup.find("span", class_="error"))
         assert error_span.text.startswith(f"ERROR: {err_msg_prefix}")
 
-    def test_pagination(self, populate_with_dataset_urls, flask_client):
+    def test_pagination(self, populate_with_std_ds_urls, flask_client):
         """
         Test pagination in Web UI
         """
@@ -272,7 +272,7 @@ class TestOverView:
         assert page_1_link.query["per_page"] == "2"
         assert page_1_link.query["sort"] == "update-desc"
 
-        assert ds_urls == set(populate_with_dataset_urls)
+        assert ds_urls == set(populate_with_std_ds_urls)
 
     @pytest.mark.usefixtures("populate_with_url_metadata")
     def test_metadata(self, flask_client):

--- a/datalad_registry/tests/test_search.py
+++ b/datalad_registry/tests/test_search.py
@@ -12,7 +12,7 @@ from ..search import parse_query
 
 @pytest.fixture
 def populate_with_url_metadata_for_search(
-    populate_with_dataset_urls,  # noqa: U100 (unused argument)
+    populate_with_std_ds_urls,  # noqa: U100 (unused argument)
     flask_app,
 ):
     """

--- a/datalad_registry/tests/test_tasks/test_chk_url_to_update.py
+++ b/datalad_registry/tests/test_tasks/test_chk_url_to_update.py
@@ -13,7 +13,7 @@ from . import FIXED_DATETIME_NOW_VALUE
 # and the db and the cache are clean
 @pytest.mark.usefixtures("flask_app")
 class TestChkUrlToUpdate:
-    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
     @pytest.mark.parametrize("invalid_url_id", [-1, 0, 5, 10])
     def test_repo_url_not_found(self, invalid_url_id):
         """
@@ -21,7 +21,7 @@ class TestChkUrlToUpdate:
         """
         assert chk_url_to_update(invalid_url_id, None) is ChkUrlStatus.ABORTED
 
-    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
     @pytest.mark.parametrize(
         "url_id, initial_last_chk_dt",
         [
@@ -38,7 +38,7 @@ class TestChkUrlToUpdate:
         """
         assert chk_url_to_update(url_id, initial_last_chk_dt) is ChkUrlStatus.SKIPPED
 
-    @pytest.mark.usefixtures("populate_with_dataset_urls", "fix_datetime_now")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls", "fix_datetime_now")
     @pytest.mark.parametrize(
         "url_id, initial_last_chk_dt, original_n_failed_chks, original_chk_req_dt",
         [

--- a/datalad_registry/tests/test_tasks/test_mark_for_chk.py
+++ b/datalad_registry/tests/test_tasks/test_mark_for_chk.py
@@ -11,7 +11,7 @@ from datalad_registry.tasks import mark_for_chk
 # and the db and the cache are clean
 @pytest.mark.usefixtures("flask_app")
 class TestMarkForChk:
-    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
     @pytest.mark.parametrize("url_id", [5, 42])
     def test_non_existing_url(self, url_id, mocker: MockerFixture):
         """
@@ -32,7 +32,7 @@ class TestMarkForChk:
 
         datetime_mock.now.assert_not_called()
 
-    @pytest.mark.usefixtures("populate_with_dataset_urls")
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
     @pytest.mark.parametrize(
         "url_id, original_chk_req_dt, expecting_chk_req_dt_changed",
         [

--- a/datalad_registry/tests/tools.py
+++ b/datalad_registry/tests/tools.py
@@ -1,0 +1,21 @@
+# This file contains helper functions for testing purposes
+
+from datalad_registry.models import RepoUrl, db
+
+
+def populate_with_dataset_urls(urls: list[RepoUrl], flask_app):
+    """
+    Populate the `repo_url` table with a list of RepoUrl objects
+
+    :param urls: The list of RepoUrl objects to populate
+    :param flask_app: The Flask app instance which provides the context for
+                      database access
+    :return: The list of URLs, expressed in `str`, that were added to the database
+    """
+
+    with flask_app.app_context():
+        for url in urls:
+            db.session.add(url)
+        db.session.commit()
+
+        return [url.url for url in urls]

--- a/datalad_registry/tests/tools.py
+++ b/datalad_registry/tests/tools.py
@@ -14,8 +14,7 @@ def populate_with_dataset_urls(urls: list[RepoUrl], flask_app):
     """
 
     with flask_app.app_context():
-        for url in urls:
-            db.session.add(url)
+        db.session.add_all(urls)
         db.session.commit()
 
         return [url.url for url in urls]

--- a/datalad_registry/tests/tools.py
+++ b/datalad_registry/tests/tools.py
@@ -1,9 +1,11 @@
 # This file contains helper functions for testing purposes
 
+from flask import Flask
+
 from datalad_registry.models import RepoUrl, db
 
 
-def populate_with_dataset_urls(urls: list[RepoUrl], flask_app):
+def populate_with_dataset_urls(urls: list[RepoUrl], flask_app: Flask) -> list[str]:
     """
     Populate the `repo_url` table with a list of RepoUrl objects
 

--- a/datalad_registry_client/tests/test_get_urls.py
+++ b/datalad_registry_client/tests/test_get_urls.py
@@ -9,8 +9,13 @@ import requests
 from yarl import URL
 
 from datalad_registry.blueprints.api.dataset_urls.models import (
+    AnnexDsCollectionStats,
+    CollectionStats,
+    DataladDsCollectionStats,
     DatasetURLPage,
     DatasetURLRespModel,
+    NonAnnexDsCollectionStats,
+    StatsSummary,
 )
 from datalad_registry_client import DEFAULT_BASE_ENDPOINT
 
@@ -38,6 +43,20 @@ dataset_url_resp_model_template = dict(
     git_objects_kb=1200,
     processed=True,
     metadata=[],
+)
+
+# A dummy `AnnexDsCollectionStats` object
+annex_ds_collection_stats = AnnexDsCollectionStats(
+    ds_count=101, annexed_files_size=1900, annexed_file_count=42
+)
+# A dummy `CollectionStats` object
+collection_stats = CollectionStats(
+    datalad_ds_stats=DataladDsCollectionStats(
+        unique_ds_stats=annex_ds_collection_stats, stats=annex_ds_collection_stats
+    ),
+    pure_annex_ds_stats=annex_ds_collection_stats,
+    non_annex_ds_stats=NonAnnexDsCollectionStats(ds_count=40),
+    summary=StatsSummary(unique_ds_count=101, ds_count=999),
 )
 
 
@@ -91,6 +110,7 @@ class TestRegistryGetURLs:
                                 url="https://www.example.com"
                             )
                         ],
+                        collection_stats=collection_stats,
                     ).json(exclude_none=True),
                 )
             else:
@@ -142,6 +162,7 @@ class TestRegistryGetURLs:
                                 url="https://www.example.com"
                             )
                         ],
+                        collection_stats=collection_stats,
                     ).json(exclude_none=True),
                 )
             else:
@@ -185,6 +206,7 @@ class TestRegistryGetURLs:
                         DatasetURLRespModel(**dataset_url_resp_model_template, url=url)
                         for url in pg
                     ],
+                    collection_stats=collection_stats,
                 )
 
         ds_url_pgs_iter = ds_url_pgs()
@@ -250,6 +272,7 @@ class TestRegistryGetURLs:
                                 url="https://www.example.com"
                             )
                         ],
+                        collection_stats=collection_stats,
                     ).json(exclude_none=True),
                 )
 


### PR DESCRIPTION
This PR provides stats regarding the returned collection of a query of dataset URLs. It closes #349.

Stats on unique datasets are only calculated on Datalad datasets. We can extend the changes in this PR to provide stats on guessed unique non-Datalad datasets in the future harvesting more info from the repos and choosing the logic that does the guessing work.

Note: 

- The changes in this PR has been applied to the instance on Typhon but not yet Falkor.
- With stats gathered, the search function is palpably slower.