### PR TITLE
Add ".datalad/config" to be a required file for `metalad_core`

### DIFF
--- a/datalad_registry/tasks/__init__.py
+++ b/datalad_registry/tasks/__init__.py
@@ -115,6 +115,7 @@ def _update_dataset_url_info(dataset_url: RepoUrl, ds: Dataset) -> None:
 # Map of extractors to their respective required files
 #     The required files are specified relative to the root of the dataset
 _EXTRACTOR_REQUIRED_FILES = {
+    "metalad_core": [".datalad/config"],
     "metalad_studyminimeta": [".studyminimeta.yaml"],
     "datacite_gin": ["datacite.yml"],
     "bids_dataset": ["dataset_description.json"],


### PR DESCRIPTION
The change in this PR will ensure the requirement of datalad-id of the `metalad_core` extractor is met in terms of required file.

The failures depicted below in running the `metalad_core` extractor be eliminated because of this change.

![Screenshot 2024-04-12 at 11 50 36 AM](https://github.com/datalad/datalad-registry/assets/12135617/52c8f38b-aca3-41f9-99d8-9113ac9cb798)

![Screenshot 2024-04-12 at 12 19 35 PM](https://github.com/datalad/datalad-registry/assets/12135617/0b544a00-c520-4243-a105-fc1f0d65fc6c)
