### PR TITLE
Remove use of `db.get_engine` in db migration code

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -15,12 +15,8 @@ logger = logging.getLogger("alembic.env")
 
 
 def get_engine():
-    try:
-        # this works with Flask-SQLAlchemy<3 and Alchemical
-        return current_app.extensions["migrate"].db.get_engine()
-    except TypeError:
-        # this works with Flask-SQLAlchemy>=3
-        return current_app.extensions["migrate"].db.engine
+    # this works with Flask-SQLAlchemy>=3
+    return current_app.extensions["migrate"].db.engine
 
 
 def get_engine_url():


### PR DESCRIPTION
We currently support `Flask-SQLAlchemy` and beyond, so `db.get_engine` is deprecated and no longer needed.

This change will remove the following deprecation warning when running migration related tasks.

```sh
/app/migrations/env.py:20: DeprecationWarning: 'get_engine' is deprecated and will be removed in Flask-SQLAlchemy 3.2. Use 'engine' or 'engines[key]' instead. If you're using Flask-Migrate or Alembic, you'll need to update your 'env.py' file.
  return current_app.extensions["migrate"].db.get_engine()
```  