### PR TITLE
Modify how `branches` are stored in the DB

### DIFF
--- a/datalad_registry/tests/test_utils/test_datalad_tls.py
+++ b/datalad_registry/tests/test_utils/test_datalad_tls.py
@@ -161,15 +161,13 @@ def test_get_origin_branches(ds_name, request, tmp_path):
 
     branch_names = set(ds.repo.get_branches())
 
-    assert set(b["name"] for b in origin_branches) == branch_names
+    assert set(origin_branches) == branch_names
 
-    for b in origin_branches:
-        b_name = b["name"]
-        assert b == {
-            "name": b_name,
-            "hexsha": ds.repo.get_hexsha(b_name),
+    for o_b_name, o_b_data in origin_branches.items():
+        assert o_b_data == {
+            "hexsha": ds.repo.get_hexsha(o_b_name),
             "last_commit_dt": ds.repo.call_git(
-                ["log", "-1", "--format=%aI", b_name]
+                ["log", "-1", "--format=%aI", o_b_name]
             ).strip(),
         }
 

--- a/datalad_registry/utils/datalad_tls.py
+++ b/datalad_registry/utils/datalad_tls.py
@@ -104,22 +104,21 @@ def get_head_describe(ds: Dataset) -> str:
     return ds.repo.describe(tags=True, always=True)
 
 
-def get_origin_branches(ds: Dataset) -> list[dict[str, str]]:
+def get_origin_branches(ds: Dataset) -> dict[str, dict[str, str]]:
     """
     Get the branches of the origin remote of a given dataset
 
     :param ds: The given dataset
-    :return: A list of dictionaries representing the branches of the origin remote
-             of the given dataset. Each dictionary has three keys, "name", "hexsha",
-             and "last_commit_dt".
-             The value of "name" is the name of the branch, the value of "hexsha"
-             is the hash of the last commit in the branch,
+    :return: A dictionary representing the branches of the origin remote
+             of the given dataset. Each branch is represented by a key-value pair in
+             which the key is the branch name and the value is a dictionary with keys,
+             "hexsha" and "last_commit_dt".
+             The value of "hexsha" is the hash of the last commit in the branch,
              and the value of "last_commit_dt" is the datetime of the last commit
              in the branch.
     """
-    return [
-        {
-            "name": branch_name,
+    return {
+        branch_name: {
             "hexsha": branch_info["objectname"],
             "last_commit_dt": branch_info["authordate:iso8601-strict"],
         }
@@ -128,7 +127,7 @@ def get_origin_branches(ds: Dataset) -> list[dict[str, str]]:
             fields=["objectname", "refname:strip=3", "authordate:iso8601-strict"],
         )
         if (branch_name := branch_info["refname:strip=3"]) != "HEAD"
-    ]
+    }
 
 
 def get_origin_default_branch(ds: Dataset) -> str:

--- a/migrations/versions/7d283978c4a9_change_repourl_branches_to_a_dict.py
+++ b/migrations/versions/7d283978c4a9_change_repourl_branches_to_a_dict.py
@@ -1,0 +1,71 @@
+"""Change RepoUrl.branches to a dict
+
+Revision ID: 7d283978c4a9
+Revises: 029941610de0
+Create Date: 2024-04-16 01:40:57.193989
+
+"""
+
+from collections.abc import Callable
+from typing import Any, cast
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql import column, table
+
+# revision identifiers, used by Alembic.
+revision = "7d283978c4a9"
+down_revision = "029941610de0"
+branch_labels = None
+depends_on = None
+
+
+def _lst_to_dict(branches: list[dict[str, str]]) -> dict[str, dict[str, str]]:
+    return {
+        branch["name"]: {
+            "hexsha": branch["hexsha"],
+            "last_commit_dt": branch["last_commit_dt"],
+        }
+        for branch in branches
+    }
+
+
+def _dict_to_lst(branches: dict[str, dict[str, str]]) -> list[dict[str, str]]:
+    return [
+        {"name": branch_name, **branch_data}
+        for branch_name, branch_data in branches.items()
+    ]
+
+
+def _migrate_branches(branches_trans_func: Callable[..., Any]) -> None:
+    bind = op.get_bind()
+
+    # Define a table representation with only the columns we need (id and branches)
+    repo_url = table("repo_url", column("id", sa.Integer), column("branches", JSONB))
+
+    # Execute a SELECT to fetch all rows
+    rows = bind.execute(sa.select(repo_url)).all()
+
+    for row in rows:
+        branches = row.branches
+
+        # Check if the branches data is not null
+        if branches is not None:
+            # Transform the list of branches into a dictionary keyed by branch name
+            new_branches = branches_trans_func(branches)
+
+            # Execute an UPDATE for each row
+            bind.execute(
+                repo_url.update()
+                .filter(repo_url.c.id == cast(int, row.id))
+                .values(branches=new_branches)
+            )
+
+
+def upgrade():
+    _migrate_branches(_lst_to_dict)
+
+
+def downgrade():
+    _migrate_branches(_dict_to_lst)


### PR DESCRIPTION
This PR modifies how `branches` are stored in the DB, from a list of dictionary to a dictionary with branch names are keys.

This PR also includes the needed migration script.

Note: Changes in this PR has been applied to the live instances of DL-Registry.