### PR TITLE
BF: allows extracted metadata to be any type

### DIFF
--- a/datalad_registry/blueprints/api/url_metadata/models.py
+++ b/datalad_registry/blueprints/api/url_metadata/models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import BaseModel, Field, StrictStr
 
 
@@ -27,7 +29,7 @@ class URLMetadataModel(_URLMetadataRep):
     dataset_version: StrictStr
     extractor_version: StrictStr
     extraction_parameter: dict
-    extracted_metadata: dict
+    extracted_metadata: Any
 
     class Config:
         orm_mode = True

--- a/datalad_registry/tests/test_blueprints/test_api/test_url_metadata.py
+++ b/datalad_registry/tests/test_blueprints/test_api/test_url_metadata.py
@@ -1,11 +1,17 @@
 import pytest
 
 from datalad_registry.blueprints.api.url_metadata import URLMetadataModel
+from datalad_registry.models import RepoUrl, URLMetadata, db
 
 
 @pytest.fixture
-def populate_with_metadata(flask_app):
-    from datalad_registry.models import RepoUrl, URLMetadata, db
+def populated_metadata(flask_app) -> list[URLMetadataModel]:
+    """
+    Populate the database with URLMetadata instances.
+
+    :return: The list of URLMetadataModel instances representing the URLMetadata
+             instances is populated to the database.
+    """
 
     url = RepoUrl(url="https://example.com")
 
@@ -35,6 +41,10 @@ def populate_with_metadata(flask_app):
         db.session.add_all(url_metadata_lst)
         db.session.commit()
 
+        return [
+            URLMetadataModel.from_orm(url_metadata) for url_metadata in url_metadata_lst
+        ]
+
 
 class TestURLMetadata:
     @pytest.mark.parametrize("url_metadata_id", [1, 2, 3, 60, 71, 100])
@@ -43,39 +53,13 @@ class TestURLMetadata:
             resp = flask_client.get(f"/api/v2/url-metadata/{url_metadata_id}")
             assert resp.status_code == 404
 
-    @pytest.mark.usefixtures("populate_with_metadata")
-    @pytest.mark.parametrize(
-        "url_metadata_id, expected_metadata",
-        [
-            (
-                1,
-                URLMetadataModel(
-                    dataset_describe="abc",
-                    dataset_version="cde",
-                    extractor_name="complete-imagination",
-                    extractor_version="0.1.0",
-                    extraction_parameter={"a": 1, "b": 2},
-                    extracted_metadata={"brave": "new world", "apple": "1984"},
-                ),
-            ),
-            (
-                2,
-                URLMetadataModel(
-                    dataset_describe="foo",
-                    dataset_version="bar",
-                    extractor_name="baz",
-                    extractor_version="1.0.0",
-                    extraction_parameter={"x": 10, "y": 20},
-                    extracted_metadata=["a", 1, {"year": 1984}],
-                ),
-            ),
-        ],
-    )
-    def test_found(self, url_metadata_id, expected_metadata, flask_client):
+    @pytest.mark.parametrize("url_metadata_id", [1, 2])
+    def test_found(self, url_metadata_id, populated_metadata, flask_client):
         resp = flask_client.get(f"/api/v2/url-metadata/{url_metadata_id}")
 
         assert resp.status_code == 200
 
         returned_metadata = URLMetadataModel.parse_obj(resp.json)
+        expected_metadata = populated_metadata[url_metadata_id - 1]
 
         assert returned_metadata == expected_metadata

--- a/datalad_registry/tests/test_blueprints/test_api/test_url_metadata.py
+++ b/datalad_registry/tests/test_blueprints/test_api/test_url_metadata.py
@@ -8,19 +8,31 @@ def populate_with_metadata(flask_app):
     from datalad_registry.models import RepoUrl, URLMetadata, db
 
     url = RepoUrl(url="https://example.com")
-    url_metadata = URLMetadata(
-        dataset_describe="abc",
-        dataset_version="cde",
-        extractor_name="complete-imagination",
-        extractor_version="0.1.0",
-        extraction_parameter={"a": 1, "b": 2},
-        extracted_metadata={"brave": "new world", "apple": "1984"},
-        url=url,
-    )
+
+    url_metadata_lst = [
+        URLMetadata(
+            dataset_describe="abc",
+            dataset_version="cde",
+            extractor_name="complete-imagination",
+            extractor_version="0.1.0",
+            extraction_parameter={"a": 1, "b": 2},
+            extracted_metadata={"brave": "new world", "apple": "1984"},
+            url=url,
+        ),
+        URLMetadata(
+            dataset_describe="foo",
+            dataset_version="bar",
+            extractor_name="baz",
+            extractor_version="1.0.0",
+            extraction_parameter={"x": 10, "y": 20},
+            extracted_metadata=["a", 1, {"year": 1984}],
+            url=url,
+        ),
+    ]
 
     with flask_app.app_context():
         db.session.add(url)
-        db.session.add(url_metadata)
+        db.session.add_all(url_metadata_lst)
         db.session.commit()
 
 
@@ -32,19 +44,38 @@ class TestURLMetadata:
             assert resp.status_code == 404
 
     @pytest.mark.usefixtures("populate_with_metadata")
-    def test_found(self, flask_client):
-        resp = flask_client.get("/api/v2/url-metadata/1")
+    @pytest.mark.parametrize(
+        "url_metadata_id, expected_metadata",
+        [
+            (
+                1,
+                URLMetadataModel(
+                    dataset_describe="abc",
+                    dataset_version="cde",
+                    extractor_name="complete-imagination",
+                    extractor_version="0.1.0",
+                    extraction_parameter={"a": 1, "b": 2},
+                    extracted_metadata={"brave": "new world", "apple": "1984"},
+                ),
+            ),
+            (
+                2,
+                URLMetadataModel(
+                    dataset_describe="foo",
+                    dataset_version="bar",
+                    extractor_name="baz",
+                    extractor_version="1.0.0",
+                    extraction_parameter={"x": 10, "y": 20},
+                    extracted_metadata=["a", 1, {"year": 1984}],
+                ),
+            ),
+        ],
+    )
+    def test_found(self, url_metadata_id, expected_metadata, flask_client):
+        resp = flask_client.get(f"/api/v2/url-metadata/{url_metadata_id}")
 
         assert resp.status_code == 200
 
         returned_metadata = URLMetadataModel.parse_obj(resp.json)
-        expected_metadata = URLMetadataModel(
-            dataset_describe="abc",
-            dataset_version="cde",
-            extractor_name="complete-imagination",
-            extractor_version="0.1.0",
-            extraction_parameter={"a": 1, "b": 2},
-            extracted_metadata={"brave": "new world", "apple": "1984"},
-        )
 
         assert returned_metadata == expected_metadata


### PR DESCRIPTION
This PR allows extracted metadata to be any type in the API response.

This change is needed because extracted metadata can be any type. The `dandi:files` extractor can return extracted metadata as a list for example.

Note: Related tests are update to better tests cases in which extracted metadata is not a `dict`.