### PR TITLE
Set up Tests GitHub Action workflow with tmate debugging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 jobs:
   test:
@@ -41,8 +48,14 @@ jobs:
         run: dotenv -f env.test list >> "$GITHUB_ENV"
       - name: Start services with Docker Compose
         run: docker compose -f docker-compose.test.yml up -d
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      # Run tests if the workflow is not triggered for debugging
       - name: Run tests with Coverage
         run: python -m pytest -s -v --cov=. --cov-report=xml
+        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.debug_enabled }}
       - name: Stop services provided by Docker Compose
         run: docker compose -f docker-compose.test.yml down
       - name: mypy check


### PR DESCRIPTION
Set up tmate debugging for the Tests GitHub Action workflow to be triggered manually