### PR TITLE
Refactor GitHub Actions workflows

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,7 +3,7 @@ name: Shellcheck on scripts
 on: [ push, pull_request ]
 
 jobs:
-  test:
+  shellcheck:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements.txt
           pip install wheel
-          pip install mypy types-requests types-PyYAML
           pip install .[test]
       - name: Remove build artifacts
         run: rm -rf build dist
@@ -58,8 +57,6 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.debug_enabled }}
       - name: Stop services provided by Docker Compose
         run: docker compose -f docker-compose.test.yml down
-      - name: mypy check
-        run: mypy datalad_registry datalad_registry_client
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v4
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.test.txt
           pip install wheel
           pip install .[test]
       - name: Remove build artifacts

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -1,0 +1,21 @@
+name: Type checks
+
+on: [ push, pull_request ]
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Tags are needed to install DL-Registry
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install dependencies and project
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.dev.txt
+          pip install .[dev]
+      - name: Run mypy
+        run: mypy datalad_registry datalad_registry_client


### PR DESCRIPTION
This PR refactor GitHub Actions workflows in the following manner.

1. Rename some of the jobs to avoid confusion
2. Remove static type checking from the `test.yml` workflow to put it in a specific workflow