### PR TITLE
Add cron script to start the falkor service

### DIFF
--- a/tools/service-falkor.sh
+++ b/tools/service-falkor.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eu
+umask 077
+
+# Log everything (very important for debugging cron)
+exec >> "$HOME/service-falkor.debug.log" 2>&1
+echo "=== $(date) starting service-falkor.sh ==="
+
+# Ensure PATH is correct (cron does NOT load your shell config)
+export PATH="/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# Go to project root
+cd "$(dirname "$0")" && cd ..
+
+echo "Working directory: $(pwd)"
+
+# Load environment variables
+set -a
+# shellcheck disable=SC1091
+source "./.env.read-only.falkor"
+set +a
+
+echo "Environment loaded"
+
+# Start service
+podman-compose -f docker-compose.read-only.yml up -d
+
+echo "=== $(date) finished ==="


### PR DESCRIPTION
## Summary
- Add `tools/service-falkor.sh` for `cron` to start the read-only service on the `falkor` server via `podman-compose`
- The script loads `.env.read-only.falkor` and logs its output to `service-falkor.debug.log` in the invoking user's home directory

## Test plan
- [x] Ran the script manually on `falkor` to confirm it starts the service and writes the log to the invoking user's home directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)