### PR TITLE
feat: add endpoint to download all dataset URLs as a JSON Lines file

### DIFF
--- a/datalad_registry/blueprints/api/dataset_urls/__init__.py
+++ b/datalad_registry/blueprints/api/dataset_urls/__init__.py
@@ -1,16 +1,18 @@
 # This file is for defining the API endpoints related to dataset URls
 
+from collections.abc import Iterator
 from json import loads
 import operator
 from pathlib import Path
 
 from celery import group
-from flask import abort, current_app, url_for
+from flask import abort, current_app, stream_with_context, url_for
 from flask_openapi3 import APIBlueprint, Tag
 from lark.exceptions import GrammarError, UnexpectedInput
 from psycopg2.errors import UniqueViolation
 from sqlalchemy import ColumnElement, and_, select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
 
 from datalad_registry.models import RepoUrl, db
 from datalad_registry.search import parse_query
@@ -27,6 +29,7 @@ from .models import (
     DatasetURLRespBaseModel,
     DatasetURLRespModel,
     DatasetURLSubmitModel,
+    DumpQueryParams,
     MetadataReturnOption,
     OrderKey,
     PathParams,
@@ -360,6 +363,64 @@ def dataset_urls(query: QueryParams):
     )
 
     return json_resp_from_str(page.json(exclude_none=True))
+
+
+@bp.get(
+    "/all",
+    responses={
+        "200": {
+            "description": "A JSON Lines (`.jsonl`) file in which each line is a JSON "
+            "object representing a dataset URL, with the same fields as an element of "
+            "the `dataset_urls` array returned by the `GET /api/v2/dataset-urls` "
+            "endpoint. Each line optionally includes the `metadata` of the dataset at "
+            "the URL, depending on the `return_metadata` flag.",
+            "content": {
+                "application/x-ndjson": {
+                    "schema": {"type": "string", "format": "binary"}
+                }
+            },
+        }
+    },
+)
+def all_dataset_urls(query: DumpQueryParams):
+    """
+    Get all dataset URLs as a single JSON Lines (`.jsonl`) file.
+
+    Each line of the returned file is a JSON object representing a dataset URL, with the
+    same fields as an element of the `dataset_urls` array returned by the
+    `GET /api/v2/dataset-urls` endpoint.
+
+    If the `return_metadata` flag is set, each line additionally includes the
+    `metadata` field populated with the metadata of the dataset at the URL by content.
+    Otherwise, each line omits the `metadata` field.
+    """
+    return_metadata = query.return_metadata
+
+    stmt = select(RepoUrl).order_by(RepoUrl.id)
+    if return_metadata:
+        # Eagerly load the metadata to avoid a separate query per dataset URL
+        stmt = stmt.options(selectinload(RepoUrl.metadata_))  # type: ignore[arg-type]
+
+    def gen_lines() -> Iterator[str]:
+        for repo_url in db.session.execute(
+            stmt.execution_options(yield_per=1000)
+        ).scalars():
+            if return_metadata:
+                line_model = DatasetURLRespModel.from_orm(repo_url)
+            else:
+                # noinspection PyArgumentList
+                line_model = DatasetURLRespModel(
+                    **DatasetURLRespBaseModel.from_orm(repo_url).dict(),
+                    metadata_=None,
+                )
+            yield line_model.json(exclude_none=True) + "\n"
+
+    resp = current_app.response_class(
+        stream_with_context(gen_lines()),
+        mimetype="application/x-ndjson",
+    )
+    resp.headers["Content-Disposition"] = "attachment; filename=dataset-urls.jsonl"
+    return resp
 
 
 @bp.get("/<int:id>", responses={"200": DatasetURLRespModel})

--- a/datalad_registry/blueprints/api/dataset_urls/models.py
+++ b/datalad_registry/blueprints/api/dataset_urls/models.py
@@ -188,6 +188,23 @@ class QueryParams(BaseModel):
     )
 
 
+class DumpQueryParams(BaseModel):
+    """
+    Pydantic model for representing the query parameters to query the endpoint that
+    returns all dataset URLs as a single JSON Lines (`.jsonl`) file
+    """
+
+    return_metadata: bool = Field(
+        False,
+        description="Whether to include the metadata of the dataset at each URL. "
+        "If this flag is not set (the default), each returned dataset URL object will "
+        "not contain a `metadata` field. If this flag is set, the `metadata` field of "
+        "each returned dataset URL object will be a list of objects each presenting a "
+        "piece of metadata of the dataset at the URL, i.e. the metadata is returned by "
+        "content.",
+    )
+
+
 class DatasetURLSubmitModel(BaseModel):
     """
     Model for representing the database model RepoUrl for submission communication

--- a/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
+++ b/datalad_registry/tests/test_blueprints/test_api/test_dataset_urls.py
@@ -919,6 +919,105 @@ class TestDatasetURLs:
         assert DatasetURLPage.parse_raw(resp.text).collection_stats == expected_stats
 
 
+class TestAllDatasetURLs:
+    @staticmethod
+    def _parse_jsonl(resp) -> list[DatasetURLRespModel]:
+        """
+        Parse the body of a response from the `all-dataset-urls` endpoint as a list of
+        `DatasetURLRespModel` objects, one per non-empty line
+        """
+        return [
+            DatasetURLRespModel.parse_raw(line)
+            for line in resp.text.splitlines()
+            if line
+        ]
+
+    def test_empty_db(self, flask_client):
+        """
+        Test the endpoint when the database contains no dataset URL
+        """
+        resp = flask_client.get("/api/v2/dataset-urls/all")
+
+        assert resp.status_code == 200
+        assert resp.mimetype == "application/x-ndjson"
+        assert resp.text == ""
+
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
+    @pytest.mark.parametrize("query_params", [{}, {"return_metadata": "false"}])
+    def test_content_disposition(self, flask_client, query_params):
+        """
+        Test that the endpoint offers its response as a downloadable `.jsonl` file
+        """
+        resp = flask_client.get("/api/v2/dataset-urls/all", query_string=query_params)
+
+        assert resp.status_code == 200
+        assert resp.mimetype == "application/x-ndjson"
+        assert (
+            resp.headers["Content-Disposition"]
+            == "attachment; filename=dataset-urls.jsonl"
+        )
+
+    @pytest.mark.usefixtures("populate_with_std_ds_urls")
+    @pytest.mark.parametrize("query_params", [{}, {"return_metadata": "false"}])
+    def test_without_metadata(self, flask_client, query_params):
+        """
+        Test that the endpoint returns all dataset URLs without metadata by default
+        """
+        resp = flask_client.get("/api/v2/dataset-urls/all", query_string=query_params)
+
+        assert resp.status_code == 200
+
+        # Every line is a valid dataset URL object without a `metadata` field
+        assert all("metadata" not in line for line in resp.text.splitlines() if line)
+
+        ds_urls = self._parse_jsonl(resp)
+
+        # All dataset URLs in the database are returned
+        assert {ds_url.url for ds_url in ds_urls} == {
+            "https://www.example.com",
+            "http://www.datalad.org",
+            "https://handbook.datalad.org",
+            "https://www.dandiarchive.org",
+        }
+
+    @pytest.mark.usefixtures("populate_with_url_metadata")
+    def test_with_metadata(self, flask_client):
+        """
+        Test that the endpoint returns all dataset URLs with metadata by content
+        when the `return_metadata` flag is set
+        """
+        resp = flask_client.get(
+            "/api/v2/dataset-urls/all", query_string={"return_metadata": "true"}
+        )
+
+        assert resp.status_code == 200
+
+        ds_urls = self._parse_jsonl(resp)
+
+        for ds_url in ds_urls:
+            assert type(ds_url.metadata) is list
+
+            if ds_url.id == 1:
+                assert len(ds_url.metadata) == 2
+            elif ds_url.id == 3:
+                assert len(ds_url.metadata) == 1
+            else:
+                assert len(ds_url.metadata) == 0
+
+            assert all(type(m) is URLMetadataModel for m in ds_url.metadata)
+
+    @pytest.mark.parametrize("return_metadata", ["abc", "2", "maybe"])
+    def test_invalid_return_metadata(self, flask_client, return_metadata):
+        """
+        Test that the endpoint rejects a non-boolean `return_metadata` flag
+        """
+        resp = flask_client.get(
+            "/api/v2/dataset-urls/all",
+            query_string={"return_metadata": return_metadata},
+        )
+        assert resp.status_code == 422
+
+
 @pytest.mark.usefixtures("populate_with_2_dataset_urls")
 class TestDatasetURL:
     @pytest.mark.parametrize("dataset_url_id", [-100, -1, 0, 2, 60, 71, 100])


### PR DESCRIPTION
Toward #407. Adds a single-file bulk download of all dataset URLs so a consumer can grab one file instead of paging `GET /api/v2/dataset-urls` hundreds of times.

## New endpoint: `GET /api/v2/dataset-urls/all`

Returns every dataset URL as a **JSON Lines** (`.jsonl`) file, one JSON object per line. Each line has the same shape as an element of the `dataset_urls` array of the paginated endpoint (a `DatasetURLRespModel`), so no internal database columns are exposed. A binary `return_metadata` flag (default `false`), the counterpart of the tri-state `return_metadata` query parameter of the paginated endpoint, controls whether each line includes the `metadata` field populated by content.

<details>
<summary>Response details and behavior</summary>

- `Content-Type: application/x-ndjson`, served as a download via `Content-Disposition: attachment; filename=dataset-urls.jsonl`.
- Without `return_metadata` (default), each line omits the `metadata` field.
- With `return_metadata=true`, each line includes `metadata` as a list of metadata objects by content, the same content form as `return_metadata=content` on the paginated endpoint.
- The response is streamed with `yield_per` so the full set of records is not serialized into memory at once, and metadata is eagerly loaded via `selectinload` when requested to avoid an N+1 query.
- The path `/all` does not collide with the existing `/<int:id>` route, since static rules take precedence over converter rules in Werkzeug.

</details>

<details>
<summary>Scope: what this intentionally leaves out</summary>

- **No filter/search parameters.** Unlike the paginated endpoint, the dump takes only `return_metadata`; it is always a full snapshot of all dataset URLs.
- **No caching or scheduled publishing.** The thread floats caching the pre-serialized gzipped bytes and publishing a dump on a schedule. Deferred as a potential follow-up: the plan is to test this endpoint in operation first, and pursue caching/publishing only if the current setup's performance is not acceptable.

</details>

## Test plan

- [x] `black`, `isort`, `flake8`, `mypy` clean on the changed files.
- [x] Full `test_dataset_urls.py` module passes (148 tests, 9 new in `TestAllDatasetURLs`).
- [x] OpenAPI spec documents the endpoint (the `application/x-ndjson` 200 response and the `return_metadata` parameter both appear at `/openapi/openapi.json`).
- [ ] Exercise the endpoint against a production-scale dataset to confirm performance is acceptable before considering the caching/publishing follow-up.

<details>
<summary>New test coverage (<code>TestAllDatasetURLs</code>)</summary>

- Empty database returns an empty body with the `application/x-ndjson` content type.
- `Content-Disposition` offers the response as `dataset-urls.jsonl`.
- Without `return_metadata`: all dataset URLs are returned and no line has a `metadata` field.
- With `return_metadata=true`: each line includes `metadata` by content, with the expected per-URL counts.
- A non-boolean `return_metadata` value is rejected with `422`.

</details>
