### PR TITLE
Start the falkor service with systemd instead of cron

### DIFF
--- a/docker-compose.read-only.yml
+++ b/docker-compose.read-only.yml
@@ -1,3 +1,9 @@
+# `read-only-db` below sets `userns_mode`, which Podman cannot combine with a
+# pod. podman-compose puts every service in a pod by default as of 1.6.0, so
+# that default has to be turned off here.
+x-podman:
+  in_pod: false
+
 services:
   read-only-web:
     build:

--- a/tools/service-falkor.service
+++ b/tools/service-falkor.service
@@ -1,0 +1,29 @@
+# A `systemd` user unit that starts the read-only Datalad-Registry service on
+# the `falkor` server. Install it with:
+#
+#     mkdir -p ~/.config/systemd/user
+#     cp tools/service-falkor.service ~/.config/systemd/user/
+#     systemctl --user daemon-reload
+#     systemctl --user enable --now service-falkor.service
+#
+# Lingering has to be enabled for the invoking user so that the unit runs at
+# boot without a login session. Verify it with
+# `loginctl show-user <user> --property=Linger`, which should report
+# `Linger=yes`.
+#
+# `Restart=on-failure` runs the script again whenever it exits non-zero. It
+# matters most at boot: the unit can run before the host network is ready, and
+# a user unit has no way to wait for it.
+
+[Unit]
+Description=Read-only Datalad-Registry service
+Documentation=https://github.com/datalad/datalad-registry
+
+[Service]
+ExecStart=%h/Developer/datalad-registry/tools/service-falkor.sh
+RemainAfterExit=yes
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target

--- a/tools/service-falkor.sh
+++ b/tools/service-falkor.sh
@@ -49,6 +49,10 @@ echo "Environment loaded"
 # otherwise wait until `read-only-db` is healthy and `read-only-web` is
 # running. Too short a timeout is harmless: the unit simply runs this script
 # again.
-podman-compose -f docker-compose.read-only.yml up -d --wait --wait-timeout 180
+#
+# `timeout` bounds the command as a whole, because `podman-compose` waits for a
+# container dependency in an unbounded loop. A run that never exits would leave
+# the unit looking healthy while the service is down.
+timeout 1h podman-compose -f docker-compose.read-only.yml up -d --wait --wait-timeout 180
 
 echo "=== $(date) finished ==="

--- a/tools/service-falkor.sh
+++ b/tools/service-falkor.sh
@@ -1,14 +1,35 @@
 #!/bin/bash
 
+# This script starts the read-only Datalad-Registry service on the `falkor`
+# server. It is meant to be invoked by the `service-falkor.service` `systemd`
+# user unit, which retries it on failure. See `tools/service-falkor.service`.
+
 set -eu
 umask 077
 
-# Log everything (very important for debugging cron)
+# Log everything (very important for debugging unattended runs)
 exec >> "$HOME/service-falkor.debug.log" 2>&1
 echo "=== $(date) starting service-falkor.sh ==="
 
-# Ensure PATH is correct (cron does NOT load your shell config)
-export PATH="/usr/local/bin:/usr/bin:/bin:$PATH"
+# `systemd` gives a user unit a minimal `PATH` and does not load any shell
+# configuration, so the search path is pinned here. `podman-compose` is
+# installed with `pipx`, which places it in `$HOME/.local/bin`.
+export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"
+
+# `XDG_RUNTIME_DIR` locates Podman's rootless runtime state, and
+# `DBUS_SESSION_BUS_ADDRESS` locates the D-Bus session bus over which Podman
+# reaches the user's `systemd` manager. Without them Podman cannot create the
+# `systemd` cgroups it uses by default and falls back to `cgroupfs`. A user
+# unit provides the first, but not always the second.
+if [ -z "${XDG_RUNTIME_DIR:-}" ]; then
+    XDG_RUNTIME_DIR="/run/user/$(id -u)"
+fi
+if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+    # A D-Bus address names a transport followed by its parameters, so this is
+    # the `unix` transport with its socket at `$XDG_RUNTIME_DIR/bus`.
+    DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
+fi
+export XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS
 
 # Go to project root
 cd "$(dirname "$0")" && cd ..
@@ -23,7 +44,11 @@ set +a
 
 echo "Environment loaded"
 
-# Start service
-podman-compose -f docker-compose.read-only.yml up -d
+# Start the service. `--wait`, which requires podman-compose 1.6.0 or later,
+# makes the command exit non-zero when a container fails to start, and
+# otherwise wait until `read-only-db` is healthy and `read-only-web` is
+# running. Too short a timeout is harmless: the unit simply runs this script
+# again.
+podman-compose -f docker-compose.read-only.yml up -d --wait --wait-timeout 180
 
 echo "=== $(date) finished ==="


### PR DESCRIPTION
## Problem

The read-only service on `falkor` did not come up after the server was rebooted. The `@reboot` `cron` entry ran before the host had a usable IPv4 default route, so `pasta` could not set up the rootless network namespace and both containers failed to start. `podman-compose up -d` then exited with 0, so nothing reported the failure and nothing retried, and the service stayed down until someone noticed.

## Changes

- Adds `tools/service-falkor.service`, a `systemd` user unit that replaces the `@reboot` `cron` entry. A user unit cannot be ordered after the host network becomes ready, so `Restart=on-failure` retries until it is.
- `tools/service-falkor.sh` pins `PATH`, sets `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` so that Podman reaches the user's `systemd` manager instead of falling back to `cgroupfs`, and passes `--wait` to `podman-compose` so that a failed start becomes a non-zero exit. `--wait` requires podman-compose 1.6.0 or later. The call is wrapped in `timeout` because `podman-compose` waits for container dependencies in an unbounded loop, and a run that never exits would leave the unit looking healthy while the service is down.
- Marks the script executable.
- `docker-compose.read-only.yml` gains `x-podman: in_pod: false`. podman-compose places every service in a pod by default as of 1.6.0, and Podman cannot combine a pod with the `userns_mode: "keep-id"` that `read-only-db` needs for its bind-mounted data directory.

## Deployment on `falkor`

- [x] Upgrade `podman-compose` to 1.6.0, which is required by the `--wait` option
- [x] Remove the `@reboot` line from `crontab -e` so that `cron` and `systemd` do not both start the service
- [x] Install and enable the user unit

The service is running on `falkor` under the new unit. The reboot behavior can only be confirmed at the next reboot, which may be months away, so it is not a blocker for merging; anything that needs adjusting can be handled then.

## Follow-ups to file as issues

- [ ] Move `typhon` off `cron` to a `systemd` user unit as well, replacing the `@reboot` entry that runs `tools/service.sh`. This PR can serve as the reference implementation. It should be taken up only once the `falkor` solution has been proven to work across a reboot.
- [ ] `docker-compose.yml` and `docker-compose.test.yml` also set `userns_mode: "keep-id"`, so they need the same `x-podman: in_pod: false` to work with podman-compose 1.6.0 or later. Left out here to keep this PR to what `falkor` needs.
- [ ] Drop the stale comments attached to `userns_mode: "keep-id"` about the setting taking effect only after podman-compose 1.0.3 and about the `PODMAN_USERNS=keep-id podman-compose up` workaround for earlier versions. They appear four times across the three compose files, and https://github.com/containers/podman-compose/issues/166 closed in 2024.
- [ ] Rebuild the `datalad-registry` image on `falkor`, which is 18 months old. Note that the rebuild is not reproducible as things stand: `requirements.txt` pins only direct dependencies, and the `Dockerfile` runs `apt-get upgrade` and installs `git-annex` unpinned, so the result depends on what the Ubuntu and PyPI repositories serve on the day.
- [ ] Rotate `~/service-falkor.debug.log` on `falkor`, which the script appends to on every run.
- [ ] Report upstream that `check_dep_conditions` in podman-compose waits for a dependency in an unbounded loop, so a missing or never-healthy dependency hangs `up` indefinitely rather than failing.
